### PR TITLE
Add buildozer and clang/llvm dev libs to Envoy CI base image.

### DIFF
--- a/build_container/README.md
+++ b/build_container/README.md
@@ -1,5 +1,5 @@
-Envoy's CI has a build run called `build_image`. On a commit to master, `ci/build_container/docker_push.sh`
-checks if the commit has changed the `ci/build_container` directory. If there are changes, CI builds a new `envoyproxy/envoy-build`
+Envoy's CI has a build run called `build_image`. On a commit to master, `build_container/docker_push.sh`
+checks if the commit has changed the `build_container` directory. If there are changes, CI builds a new `envoyproxy/envoy-build`
 image. The image is pushed to [dockerhub](https://hub.docker.com/r/envoyproxy/envoy-build/tags/) under `latest` and under the commit sha.
 
 After the PR that changes `ci/build_container` has been merged, and the new image gets pushed,

--- a/build_container/build_container_common.sh
+++ b/build_container/build_container_common.sh
@@ -1,9 +1,16 @@
 #!/bin/bash -e
 
 if [[ "$(uname -m)" == "x86_64" ]]; then
+  # buildozer
+  VERSION=0.29.0
+  SHA256=2a5c3e3390de07248704f21ed38495062fb623c9b0aef37deda257a917891ea6
+  curl --location --output /usr/local/bin/buildozer https://github.com/bazelbuild/buildtools/releases/download/"$VERSION"/buildozer \
+    && echo "$SHA256  /usr/local/bin/buildozer" | sha256sum --check \
+    && chmod +x /usr/local/bin/buildozer
+
   # buildifier
-  VERSION=0.28.0
-  SHA256=3d474be62f8e18190546881daf3c6337d857bf371faf23f508e9b456b0244267
+  VERSION=0.29.0
+  SHA256=4c985c883eafdde9c0e8cf3c8595b8bfdf32e77571c369bf8ddae83b042028d6
   curl --location --output /usr/local/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/"$VERSION"/buildifier \
     && echo "$SHA256  /usr/local/bin/buildifier" | sha256sum --check \
     && chmod +x /usr/local/bin/buildifier

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -37,7 +37,8 @@ case $ARCH in
         wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
         apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
         apt-get update
-        apt-get install -y --no-install-recommends clang-9 clang-format-9 clang-tidy-9 lld-9 libc++-9-dev libc++abi-9-dev llvm-9
+        apt-get install -y --no-install-recommends clang-9 clang-format-9 clang-tidy-9 lld-9 libc++-9-dev libc++abi-9-dev \
+          libclang-9-dev llvm-9-dev llvm-9
         ;;
 esac
 


### PR DESCRIPTION
* Add buildozer 0.29.0, since this is useful in check/fix_format
  handling of BUILD files.

* Bump buildifier to 0.29.0, for consistency with ^^, since they share a
  release clock and provenance.

* Add libclang-9-dev and llvm-9-dev to Ubuntu image for the include/libs needed for libtooling.

* Some minor README.md fixes.

Signed-off-by: Harvey Tuch <htuch@google.com>