### PR TITLE
build: python3.8 support in build container.

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -39,10 +39,10 @@ apt-get update -y
 apt-get install -y --no-install-recommends docker-ce-cli wget make cmake git python python-pip python-setuptools python3 python3-pip \
   unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client google-cloud-sdk
 
-# Python 3.7
+# Python 3.8
 add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
-apt install -y python3.7
+apt install -y python3.8
 
 LLVM_VERSION=9.0.0
 case $ARCH in

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -39,6 +39,11 @@ apt-get update -y
 apt-get install -y --no-install-recommends docker-ce-cli wget make cmake git python python-pip python-setuptools python3 python3-pip \
   unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client google-cloud-sdk
 
+# Python 3.7
+add-apt-repository -y ppa:deadsnakes/ppa
+apt-get update
+apt install -y python3.7
+
 LLVM_VERSION=9.0.0
 case $ARCH in
     'ppc64le' )


### PR DESCRIPTION
The default Ubuntu supplied 16.05 python3.5 continues to be the default
python3 and will be used in most places. python3.8 from deadsnakes/ppa
is available for scripts that rely on more recent features.

Signed-off-by: Harvey Tuch <htuch@google.com>