### PR TITLE
Enable build multi-arch ubuntu docker-images

### DIFF
--- a/build_container/Dockerfile-centos
+++ b/build_container/Dockerfile-centos
@@ -1,7 +1,25 @@
-FROM centos:7
+#Add qemu function for supporting multiarch
+ARG IMAGEARCH
+FROM alpine:3.9.2 as qemu
+RUN apk add --no-cache curl
+ARG QEMUVERSION=2.9.1
+ARG QEMUARCH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMUVERSION}/qemu-${QEMUARCH}-static.tar.gz | tar zxvf - -C /usr/bin
+RUN chmod +x /usr/bin/qemu-*
+
+FROM ${IMAGEARCH}centos:7
+
+ARG QEMUARCH
+COPY --from=qemu /usr/bin/qemu-${QEMUARCH}-static /usr/bin/
 
 COPY ./build_container_common.sh /
 COPY ./build_container_centos.sh /
 
 ENV PATH /opt/rh/rh-git218/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:/opt/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN ./build_container_centos.sh
+
+# In the end, remove qemu program
+RUN rm -f /usr/bin/qemu-${QEMUARCH}-static

--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -1,6 +1,24 @@
-FROM ubuntu:xenial
+#Add qemu function for supporting multiarch
+ARG IMAGEARCH
+FROM alpine:3.9.2 as qemu
+RUN apk add --no-cache curl
+ARG QEMUVERSION=2.9.1
+ARG QEMUARCH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMUVERSION}/qemu-${QEMUARCH}-static.tar.gz | tar zxvf - -C /usr/bin
+RUN chmod +x /usr/bin/qemu-*
+
+FROM ${IMAGEARCH}ubuntu:xenial
+
+ARG QEMUARCH
+COPY --from=qemu /usr/bin/qemu-${QEMUARCH}-static /usr/bin/
 
 COPY ./build_container_common.sh /
 COPY ./build_container_ubuntu.sh /
 
 RUN ./build_container_ubuntu.sh
+
+# Remove qemu program
+RUN rm -f /usr/bin/qemu-${QEMUARCH}-static

--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 set -e
-
+ARCH="$(uname -m)"
 # Note: rh-git218 is needed to run `git -C` in docs build process.
-yum install -y centos-release-scl epel-release
+if [[ "${ARCH}" == "x86_64" ]]; then
+  yum install -y centos-release-scl epel-release
+fi
 yum update -y
 yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-1.8.0-openjdk-headless rsync \
     rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
@@ -14,7 +16,16 @@ ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 # SLES 11 has older glibc than CentOS 7, so pre-built binary for it works on CentOS 7
 LLVM_VERSION=8.0.0
-LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-x86_64-linux-sles11.3"
+
+case $ARCH in
+    'x86_64' )
+        LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-x86_64-linux-sles11.3"
+        ;;
+    'aarch64' )
+        LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu"
+        ;;
+esac
+
 curl -OL "https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz"
 tar Jxf "${LLVM_RELEASE}.tar.xz"
 mv "./${LLVM_RELEASE}" /opt/llvm

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -39,6 +39,16 @@ case $ARCH in
         apt-get update
         apt-get install -y --no-install-recommends clang-8 clang-format-8 clang-tidy-8 lld-8 libc++-8-dev libc++abi-8-dev llvm-8
         ;;
+    'aarch64' )
+        LLVM_VERSION=8.0.0
+        LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-aarch64-linux-gnu"
+        wget "https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz"
+        tar Jxf "${LLVM_RELEASE}.tar.xz"
+        mv "./${LLVM_RELEASE}" /opt/llvm
+        rm "./${LLVM_RELEASE}.tar.xz"
+        echo "/opt/llvm/lib" > /etc/ld.so.conf.d/llvm.conf
+        ldconfig
+        ;;
 esac
 
 # Bazel and related dependencies.
@@ -49,6 +59,18 @@ case $ARCH in
         curl -fSL https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_16.04/latest/${BAZEL_LATEST} \
           -o /usr/local/bin/bazel
         chmod +x /usr/local/bin/bazel
+        ;;
+    'aarch64' )
+        #Install bazel on Arm64 platform by Ubuntu PPA repository
+        if [ "$(lsb_release -cs)" == 'xenial' ]; then
+          apt install -y openjdk-8-jdk
+        else
+          apt install -y openjdk-11-jdk
+        fi
+
+        add-apt-repository ppa:kingofcodecplusplus/bazel120
+        apt-get update
+        apt install -y bazel
         ;;
 esac
 

--- a/build_container/docker_build.sh
+++ b/build_container/docker_build.sh
@@ -1,6 +1,48 @@
 #!/bin/bash
 
+#The ppc64le is not supportted by google-cloud-sdk. So ppc64le is temporary removed.
+IMAGE_ARCH=("amd64" "arm64")
+
+buildImage()
+{
+    ARCH=$1
+
+    case ${ARCH:-} in
+    'amd64')
+        QEMUARCH='x86_64'
+        ;;
+    'arm64')
+        IMAGEARCH='arm64v8/'
+        QEMUARCH='aarch64'
+        ;;
+    'ppc64le')
+        IMAGEARCH='ppc64le/'
+        QEMUARCH='ppc64le'
+        ;;
+    *)
+        echo 'Cpu architecture is not supportted!'
+        exit 1
+        ;;
+    esac
+
+    BUILD_NAME="${IMAGE_NAME}"
+    echo "build ${BUILD_NAME}:${CONTAINER_TAG}-${ARCH}"
+
+    docker build --build-arg IMAGEARCH=${IMAGEARCH} \
+                   --build-arg QEMUARCH=${QEMUARCH} \
+                   -f Dockerfile-${LINUX_DISTRO} -t ${BUILD_NAME}:${CONTAINER_TAG}-${ARCH} .
+}
+
+#For test
+#CONTAINER_TAG=latest
+#LINUX_DISTRO="ubuntu"
+#LINUX_DISTRO="centos"
+
 [[ -z "${LINUX_DISTRO}" ]] && LINUX_DISTRO="ubuntu"
 [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=envoyproxy/envoy-build-"${LINUX_DISTRO}"
 
-docker build -f Dockerfile-${LINUX_DISTRO} -t ${IMAGE_NAME}:${CONTAINER_TAG} .
+for arch in "${IMAGE_ARCH[@]}"
+do
+    echo "Build the $arch image"
+    buildImage $arch
+done

--- a/build_container/docker_push.sh
+++ b/build_container/docker_push.sh
@@ -4,6 +4,8 @@
 # CI logs.
 set -e
 
+IMAGE_ARCH=("amd64" "arm64")
+
 CONTAINER_SHA=$(git log -1 --pretty=format:"%H" .)
 
 echo "Building envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}"
@@ -17,16 +19,33 @@ CONTAINER_TAG=${CONTAINER_SHA} ./docker_build.sh
 if [[ "${SOURCE_BRANCH}" == "refs/heads/master" ]]; then
     docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-    docker push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}
+    for arch in "${IMAGE_ARCH[@]}"
+    do
+        docker push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-${arch}
+    done
+
+    docker manifest create envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA} \
+	    envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-arm64 \
+	    envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-amd64
+
+    for arch in "${IMAGE_ARCH[@]}"
+    do
+        docker manifest annotate envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA} \
+		envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-${arch} \
+		--os linux --arch ${arch}
+    done
+
+    docker manifest push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}
 
     if [[ "${LINUX_DISTRO}" == "ubuntu" ]]; then
         echo ${GCP_SERVICE_ACCOUNT_KEY} | base64 --decode | gcloud auth activate-service-account --key-file=-
         gcloud auth configure-docker --quiet
 
         echo "Updating gcr.io/envoy-ci/envoy-build image"
-        docker tag envoyproxy/envoy-build-"${LINUX_DISTRO}":"${CONTAINER_SHA}" gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}"
-        docker push gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}"
+        docker tag envoyproxy/envoy-build-"${LINUX_DISTRO}":"${CONTAINER_SHA}-${arch}" gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}-${arch}"
+        docker push gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}-${arch}"
     fi
+
 else
     echo 'Ignoring PR branch for docker push.'
 fi


### PR DESCRIPTION
In this patch, we will enable building multi-arch ubuntu image which is
used for building envoy from source code by qemu.

1. Update the Dockerfile for supporting qemu crosscompiler tools
   In Dockerfiles, the qemu tools were added for building the
   different platform images on x86 platform. It will firstly get
   the qemu tools from website, then copy the qemu tools into target
   images. Finnal, run the scripts.

2. Update the Ubuntu building scripts which used in docker image
   In the building scripts, "aarch64" options were added. Firstly,
   clang8 is installed in the scrpts. Then, the bazel is installed
   from Ubuntu PPA.

3. Modify the build scripts for supporting multi-arch build.
   Some aarch options were added in docker_build.sh for supporting
   qemu tools. At the same time, the name of image is modified for
   distinguishing different platform

4. Modify the docker-push scripts for supporting multi-arch images.
   In docker_push.sh file, the docker manifest tool is used for pushing
   multi-arch images into dockerhub.

5. In addition, the ppc64le does not supported by this scripts since
   it does not supported by google-cloud-sdk, the application installed
   in the scripts. We will update it until the corresponding application
   is OK.

6. Update the Centos building scripts.
   Although the centos scripts were updated, we still can not successfully
   build the envoy on centOS arm64-image. It mainly because that some
   binary packages were not supportted on centOS. We have to build those
   tools from source code. So we temporary remove it and will update it
   until those packages were supportted.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>