### PR TITLE
Enable build multi-arch ubuntu docker-images

### DIFF
--- a/build_container/Dockerfile-centos
+++ b/build_container/Dockerfile-centos
@@ -1,7 +1,25 @@
-FROM centos:7
+#Add qemu function for supporting multiarch
+ARG IMAGEARCH
+FROM alpine:3.9.2 as qemu
+RUN apk add --no-cache curl
+ARG QEMUVERSION=2.9.1
+ARG QEMUARCH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMUVERSION}/qemu-${QEMUARCH}-static.tar.gz | tar zxvf - -C /usr/bin
+RUN chmod +x /usr/bin/qemu-*
+
+FROM ${IMAGEARCH}centos:7
+
+ARG QEMUARCH
+COPY --from=qemu /usr/bin/qemu-${QEMUARCH}-static /usr/bin/
 
 COPY ./build_container_common.sh /
 COPY ./build_container_centos.sh /
 
 ENV PATH /opt/rh/rh-git218/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:/opt/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN ./build_container_centos.sh
+
+# In the end, remove qemu program
+RUN rm -f /usr/bin/qemu-${QEMUARCH}-static

--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -1,6 +1,23 @@
-FROM ubuntu:xenial
+#Add qemu function for supporting multiarch
+ARG IMAGEARCH
+FROM alpine:3.9.2 as qemu
+RUN apk add --no-cache curl
+ARG QEMUVERSION=2.9.1
+ARG QEMUARCH
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+RUN curl -fsSL https://github.com/multiarch/qemu-user-static/releases/download/v${QEMUVERSION}/qemu-${QEMUARCH}-static.tar.gz | tar zxvf - -C /usr/bin
+RUN chmod +x /usr/bin/qemu-*
+
+FROM ${IMAGEARCH}ubuntu:xenial
+ARG QEMUARCH
+COPY --from=qemu /usr/bin/qemu-${QEMUARCH}-static /usr/bin/
 
 COPY ./build_container_common.sh /
 COPY ./build_container_ubuntu.sh /
 
 RUN ./build_container_ubuntu.sh
+
+# Remove qemu program
+RUN rm -f /usr/bin/qemu-${QEMUARCH}-static

--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 set -e
-
+ARCH="$(uname -m)"
 # Note: rh-git218 is needed to run `git -C` in docs build process.
-yum install -y centos-release-scl epel-release
+if [[ "${ARCH}" == "x86_64" ]]; then
+  yum install -y centos-release-scl epel-release
+fi
 yum update -y
 yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-1.8.0-openjdk-headless rsync \
     rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
@@ -14,8 +16,17 @@ ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 # SLES 11 has older glibc than CentOS 7, so pre-built binary for it works on CentOS 7
 LLVM_VERSION=9.0.0
-LLVM_DISTRO="x86_64-linux-sles11.3"
-LLVM_SHA256SUM="c80b5b10df191465df8cee8c273d9c46715e6f27f80fef118ad4ebb7d9f3a7d3"
+
+case $ARCH in
+    'x86_64' )
+        LLVM_DISTRO="x86_64-linux-sles11.3"
+        LLVM_SHA256SUM="c80b5b10df191465df8cee8c273d9c46715e6f27f80fef118ad4ebb7d9f3a7d3"
+        ;;
+    'aarch64' )
+        LLVM_DISTRO="aarch64-linux-gnu"
+        LLVM_SHA256SUM="f8f3e6bdd640079a140a7ada4eb6f5f05aeae125cf54b94d44f733b0e8691dc2"
+        ;;
+esac
 
 # httpd24 is equired by rh-git218
 echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf
@@ -26,5 +37,13 @@ groupadd pcap
 chgrp pcap /usr/sbin/tcpdump
 chmod 750 /usr/sbin/tcpdump
 setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
+
+# The build_container_common.sh will be skipped when building centOS
+# image on Arm64 platform since some building issues are still unsolved. 
+# It will be fixed until those issues solved on Arm64 platform.
+if [[ $(uname -m) == "aarch64" ]] && grep -q -e rhel /etc/*-release ; then
+  echo "Now, the CentOS image can not be built on arm64 platform!"
+  exit 0
+fi
 
 source ./build_container_common.sh

--- a/build_container/build_container_common.sh
+++ b/build_container/build_container_common.sh
@@ -29,6 +29,12 @@ if [[ "$(uname -m)" == "x86_64" ]]; then
   chmod +x /usr/local/bin/bazel
 fi
 
+if [[ "$(uname -m)" == "aarch64" ]]; then
+  download_and_check /usr/local/bin/bazel https://github.com/Tick-Tocker/bazelisk-arm64/releases/download/arm64/bazelisk-linux-arm64 \
+    bcbb11c014d78d4cb8c8d335daf41eefe274a64db9df778025ec12ad0aae3d80
+  chmod +x /usr/local/bin/bazel
+fi
+
 LLVM_RELEASE="clang+llvm-${LLVM_VERSION}-${LLVM_DISTRO}"
 download_and_check "${LLVM_RELEASE}.tar.xz" "https://releases.llvm.org/${LLVM_VERSION}/${LLVM_RELEASE}.tar.xz" "${LLVM_SHA256SUM}"
 tar Jxf "${LLVM_RELEASE}.tar.xz"
@@ -67,3 +73,4 @@ fi
 rm -rf /opt/libcxx_msan/include
 
 popd
+

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -33,6 +33,9 @@ case $ARCH in
     'x86_64' )
         add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
         ;;
+    'aarch64' )
+        add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+        ;;
 esac
 apt-get update -y
 
@@ -55,6 +58,10 @@ case $ARCH in
         LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04
         LLVM_SHA256SUM=5c1473c2611e1eac4ed1aeea5544eac5e9d266f40c5623bbaeb1c6555815a27d
         ;;
+    'aarch64' )
+        LLVM_DISTRO=aarch64-linux-gnu
+        LLVM_SHA256SUM=f8f3e6bdd640079a140a7ada4eb6f5f05aeae125cf54b94d44f733b0e8691dc2
+        ;;
 esac
 
 # Bazel and related dependencies.
@@ -65,6 +72,15 @@ case $ARCH in
         curl -fSL https://oplab9.parqtec.unicamp.br/pub/ppc64el/bazel/ubuntu_16.04/latest/${BAZEL_LATEST} \
           -o /usr/local/bin/bazel
         chmod +x /usr/local/bin/bazel
+        ;;
+    'aarch64' )
+        if [ "$(lsb_release -cs)" == 'xenial' ]; then
+          apt install -y openjdk-8-jdk
+          apt install -y ca-certificates-java
+          update-ca-certificates -f
+        else
+          apt install -y openjdk-11-jdk
+        fi
         ;;
 esac
 

--- a/build_container/docker_build.sh
+++ b/build_container/docker_build.sh
@@ -1,6 +1,44 @@
 #!/bin/bash
+#The ppc64le is not supportted by google-cloud-sdk. So ppc64le is temporary removed.
+IMAGE_ARCH=("amd64" "arm64")
+
+build_image()
+{
+    ARCH=$1
+
+    case ${ARCH:-} in
+    'amd64')
+        QEMUARCH='x86_64'
+        ;;
+    'arm64')
+        IMAGEARCH='arm64v8/'
+        QEMUARCH='aarch64'
+        ;;
+    'ppc64le')
+        IMAGEARCH='ppc64le/'
+        QEMUARCH='ppc64le'
+        ;;
+    *)
+        echo 'Cpu architecture is not supportted!'
+        exit 1
+        ;;
+    esac
+
+    BUILD_NAME="${IMAGE_NAME}"
+    echo "build ${BUILD_NAME}:${CONTAINER_TAG}-${ARCH}"
+
+    docker build --build-arg IMAGEARCH=${IMAGEARCH} \
+                   --build-arg QEMUARCH=${QEMUARCH} \
+                   -f Dockerfile-${LINUX_DISTRO} -t ${BUILD_NAME}:${CONTAINER_TAG}-${ARCH} .
+}
+
+docker run --rm --privileged multiarch/qemu-user-static:register --reset
 
 [[ -z "${LINUX_DISTRO}" ]] && LINUX_DISTRO="ubuntu"
 [[ -z "${IMAGE_NAME}" ]] && IMAGE_NAME=envoyproxy/envoy-build-"${LINUX_DISTRO}"
 
-docker build -f Dockerfile-${LINUX_DISTRO} -t ${IMAGE_NAME}:${CONTAINER_TAG} .
+for arch in "${IMAGE_ARCH[@]}"
+do
+    echo "Build the $arch image"
+    build_image $arch
+done

--- a/build_container/docker_push.sh
+++ b/build_container/docker_push.sh
@@ -4,6 +4,8 @@
 # CI logs.
 set -e
 
+IMAGE_ARCH=("amd64" "arm64")
+
 CONTAINER_SHA=$(git log -1 --pretty=format:"%H" .)
 
 echo "Building envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}"
@@ -17,16 +19,33 @@ CONTAINER_TAG=${CONTAINER_SHA} ./docker_build.sh
 if [[ "${SOURCE_BRANCH}" == "refs/heads/master" ]]; then
     docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
 
-    docker push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}
+    for arch in "${IMAGE_ARCH[@]}"
+    do
+        docker push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-${arch}
+    done
+
+    docker manifest create envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA} \
+	    envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-arm64 \
+	    envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-amd64
+
+    for arch in "${IMAGE_ARCH[@]}"
+    do
+        docker manifest annotate envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA} \
+		envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-${arch} \
+		--os linux --arch ${arch}
+    done
+
+    docker manifest push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}
 
     if [[ "${LINUX_DISTRO}" == "ubuntu" ]]; then
         echo ${GCP_SERVICE_ACCOUNT_KEY} | base64 --decode | gcloud auth activate-service-account --key-file=-
         gcloud auth configure-docker --quiet
 
         echo "Updating gcr.io/envoy-ci/envoy-build image"
-        docker tag envoyproxy/envoy-build-"${LINUX_DISTRO}":"${CONTAINER_SHA}" gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}"
-        docker push gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}"
+        docker tag envoyproxy/envoy-build-"${LINUX_DISTRO}":"${CONTAINER_SHA}-${arch}" gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}-${arch}"
+        docker push gcr.io/envoy-ci/envoy-build:"${CONTAINER_SHA}-${arch}"
     fi
+
 else
     echo 'Ignoring PR branch for docker push.'
 fi


### PR DESCRIPTION
In this patch, we will enable building multi-arch ubuntu image which is
used for building envoy from source code by qemu.

1. Update the Dockerfile for supporting qemu crosscompiler tools
   In Dockerfiles, the qemu tools were added for building the
   different platform images on x86 platform. It will firstly get
   the qemu tools from website, then copy the qemu tools into target
   images. Finnal, run the scripts.

2. Update the Ubuntu building scripts which used in docker image
   In the building scripts, "aarch64" options were added. Firstly,
   clang8 is installed in the scrpts. Then, the bazel is installed
   from Ubuntu PPA.

3. Modify the build scripts for supporting multi-arch build.
   Some aarch options were added in docker_build.sh for supporting
   qemu tools. At the same time, the name of image is modified for
   distinguishing different platform

4. Modify the docker-push scripts for supporting multi-arch images.
   In docker_push.sh file, the docker manifest tool is used for pushing
   multi-arch images into dockerhub.

5. In addition, the ppc64le does not supported by this scripts since
   it does not supported by google-cloud-sdk, the application installed
   in the scripts. We will update it until the corresponding application
   is OK.

6. Update the Centos building scripts.
   Although the centos scripts were updated, we still can not successfully
   build the envoy on centOS arm64-image. It mainly because that some
   binary packages were not supportted on centOS. We have to build those
   tools from source code. So we temporary remove it and will update it
   until those packages were supportted.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>