### PR TITLE
build: Add doxygen and graphviz to container

### DIFF
--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -7,7 +7,7 @@ yum install -y centos-release-scl epel-release
 yum update -y
 yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-1.8.0-openjdk-headless rsync \
     rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
-    libtool autoconf tcpdump
+    libtool autoconf tcpdump graphviz doxygen
 
 ln -s /usr/bin/cmake3 /usr/bin/cmake
 ln -s /usr/bin/ninja-build /usr/bin/ninja

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -38,7 +38,7 @@ apt-get update -y
 
 apt-get install -y --no-install-recommends docker-ce-cli wget make cmake git python python-pip python-setuptools python3 python3-pip \
   unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client google-cloud-sdk \
-  libncurses-dev
+  libncurses-dev doxygen graphviz
 
 # Python 3.8
 add-apt-repository -y ppa:deadsnakes/ppa


### PR DESCRIPTION
Working on adding Doxygen documentation for the C++ files, to do that need both Doxygen and GraphViz in the build container.

Context:
https://github.com/envoyproxy/envoy/issues/579

Signed-off-by: Mark Mandel <markmandel@google.com>