### PR TITLE
Enable docker experimental feature

### DIFF
--- a/build_container/docker_push.sh
+++ b/build_container/docker_push.sh
@@ -4,6 +4,9 @@
 # CI logs.
 set -e
 
+# Enable docker experimental
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
 IMAGE_ARCH=("amd64" "arm64")
 
 CONTAINER_SHA=$(git log -1 --pretty=format:"%H" .)
@@ -24,7 +27,7 @@ if [[ "${SOURCE_BRANCH}" == "refs/heads/master" ]]; then
         docker push envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-${arch}
     done
 
-    docker manifest create envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA} \
+    docker manifest create --amend envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA} \
 	    envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-arm64 \
 	    envoyproxy/envoy-build-${LINUX_DISTRO}:${CONTAINER_SHA}-amd64
 


### PR DESCRIPTION
Docker manifest is the docker experimental feature, it
is not supported in default mode.
In this patch, DOCKER_CLI_EXPERIMENTAL is set with value
"enabled" to enable it.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>