### PR TITLE
Update the docker version to 19.03

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,11 @@ jobs:
     vmImage: 'ubuntu-16.04'
   container: google/cloud-sdk:latest
   steps:
+  - task: DockerInstaller@0
+    displayName: Docker Installer
+    inputs:
+      dockerVersion: 19.03.5
+      releaseType: stable
   - bash: |
       ./docker_push.sh
     workingDirectory: build_container


### PR DESCRIPTION
The version of docker in Azure default Ubuntu 16.04 image is too old
to well support docker experimental feature. So, in this patch, it
updates the docker version from 17.12.0-ce to 19.03.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>