### PR TITLE
Update qemu version for ca-certificates error

### DIFF
--- a/build_container/Dockerfile-centos
+++ b/build_container/Dockerfile-centos
@@ -2,7 +2,7 @@
 ARG IMAGEARCH
 FROM alpine:3.9.2 as qemu
 RUN apk add --no-cache curl
-ARG QEMUVERSION=2.9.1
+ARG QEMUVERSION=4.0.0
 ARG QEMUARCH
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -2,7 +2,7 @@
 ARG IMAGEARCH
 FROM alpine:3.9.2 as qemu
 RUN apk add --no-cache curl
-ARG QEMUVERSION=2.9.1
+ARG QEMUVERSION=4.0.0
 ARG QEMUARCH
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Update the qemu version from 2.9.1 to 4.0.0 for fixing
update-ca-certificates failed when building docker images.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>