### PR TITLE
Add essential software into docker build image

### DIFF
--- a/build_container/build_container_common.sh
+++ b/build_container/build_container_common.sh
@@ -9,6 +9,31 @@ function download_and_check () {
   echo "${sha256}  ${to}" | sha256sum --check
 }
 
+function install_gn(){
+    GN_COMMIT_ID="a899709c3b024eddade4cf7eab167b5962164fb0"
+    git clone https://gn.googlesource.com/gn
+    cd gn
+    git checkout ${GN_COMMIT_ID}
+    python build/gen.py
+    ninja -C out
+    cp out/gn /usr/bin/
+
+    # Clear environments
+    cd .. && rm -rf gn/
+}
+
+function update_ninja(){
+    NINJA_VERSION="1.8.2"
+    curl -fsSL --output ninja.zip https://github.com/ninja-build/ninja/archive/v${NINJA_VERSION}.zip
+    unzip ninja.zip
+    cd ninja-${NINJA_VERSION}
+    ./configure.py --bootstrap
+    cp ninja /usr/bin/
+
+    # Clear environments
+    cd .. && rm -rf ninja*
+}
+
 if [[ "$(uname -m)" == "x86_64" ]]; then
   # buildifier
   VERSION=0.29.0
@@ -46,6 +71,12 @@ ldconfig
 
 # MSAN
 export PATH="/opt/llvm/bin:${PATH}"
+
+# Update ninja to 1.8.2
+update_ninja
+
+# Install gn tools which will be used for envoy tests.
+install_gn
 
 WORKDIR=$(mktemp -d)
 function cleanup {


### PR DESCRIPTION
1. Add gn software into docker image which will be used for
   building envoy test cases.
2. Upgrade the ninja software from 1.5.1 to 1.8.2 for wee8
   build in envoy test cases.

Signed-off-by: Jingzhao.Ni <Jingzhao.Ni@arm.com>