### PR TITLE
Add essential software into docker build image

### DIFF
--- a/build_container/build_container_common.sh
+++ b/build_container/build_container_common.sh
@@ -9,6 +9,19 @@ function download_and_check () {
   echo "${sha256}  ${to}" | sha256sum --check
 }
 
+function install_gn(){
+    GN_COMMIT_ID="a899709c3b024eddade4cf7eab167b5962164fb0"
+    git clone https://gn.googlesource.com/gn
+    cd gn
+    git checkout ${GN_COMMIT_ID}
+    python build/gen.py
+    ninja -C out
+    cp out/gn /usr/bin/
+
+    # Clear environments
+    cd .. && rm -rf gn/
+}
+
 if [[ "$(uname -m)" == "x86_64" ]]; then
   # buildifier
   VERSION=0.29.0
@@ -46,6 +59,9 @@ ldconfig
 
 # MSAN
 export PATH="/opt/llvm/bin:${PATH}"
+
+# Install gn tools which will be used for envoy tests.
+install_gn
 
 WORKDIR=$(mktemp -d)
 function cleanup {

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -40,7 +40,7 @@ esac
 apt-get update -y
 
 apt-get install -y --no-install-recommends docker-ce-cli wget make cmake git python python-pip python-setuptools python3 python3-pip \
-  python3-setuptools unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client google-cloud-sdk \
+  python3-setuptools unzip bc libtool automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client google-cloud-sdk \
   libncurses-dev doxygen graphviz
 
 # Python 3.8
@@ -48,19 +48,38 @@ add-apt-repository -y ppa:deadsnakes/ppa
 apt-get update
 apt install -y python3.8
 
-LLVM_VERSION=9.0.0
+# Install ninja-build 1.8.2 from binary
 case $ARCH in
     'ppc64le' )
+        ninja_deb="ninja-build_1.8.2-1_ppc64el.deb"
+        ;;
+    'x86_64' )
+        ninja_deb="ninja-build_1.8.2-1_amd64.deb"
+        ;;
+    'aarch64' )
+        ninja_deb="ninja-build_1.8.2-1_arm64.deb"
+        ;;
+esac
+wget https://launchpad.net/ubuntu/+archive/primary/+files/${ninja_deb}
+dpkg -i ${ninja_deb}
+rm ${ninja_deb}
+
+# Set LLVM version for each cpu architecture.
+case $ARCH in
+    'ppc64le' )
+        LLVM_VERSION=9.0.0
         LLVM_DISTRO=powerpc64le-linux-ubuntu-16.04
         LLVM_SHA256SUM=a8e7dc00e9eac47ea769eb1f5145e1e28f0610289f07f3275021f0556c169ddf
         ;;
     'x86_64' )
+        LLVM_VERSION=9.0.0
         LLVM_DISTRO=x86_64-linux-gnu-ubuntu-16.04
         LLVM_SHA256SUM=5c1473c2611e1eac4ed1aeea5544eac5e9d266f40c5623bbaeb1c6555815a27d
         ;;
     'aarch64' )
+        LLVM_VERSION=8.0.0
         LLVM_DISTRO=aarch64-linux-gnu
-        LLVM_SHA256SUM=f8f3e6bdd640079a140a7ada4eb6f5f05aeae125cf54b94d44f733b0e8691dc2
+        LLVM_SHA256SUM=998e9ae6e89bd3f029ed031ad9355c8b43441302c0e17603cf1de8ee9939e5c9
         ;;
 esac
 


### PR DESCRIPTION
1. Add gn software into docker image which will be used for
   building envoy test cases.
2. Upgrade the ninja software from 1.5.1 to 1.8.2 for wee8
   build in envoy test cases.
3. Change arm64 toolchain from clang-9 to clang-8 since building
   errors.

Signed-off-by: Jingzhao.Ni <Jingzhao.Ni@arm.com>