### PR TITLE
Windows image: Symlink workaround for msys2

### DIFF
--- a/build_container/Dockerfile-windows2019
+++ b/build_container/Dockerfile-windows2019
@@ -4,6 +4,9 @@ ENV MSYS2_ARG_CONV_EXCL "*"
 
 ENV TMPDIR C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp
 
+# Ensures paths rooted at /c/ can be found by programs running via msys2 shell
+RUN cmd.exe /c "mklink /D C:\c C:\"
+
 COPY ./build_container_windows.ps1 /
 
 RUN powershell.exe .\\build_container_windows.ps1


### PR DESCRIPTION
- we need to bake this into the container image so scripts run in msys2
executed via RBE have the ability to resolve paths as expected
- similar to workaround in envoy windows CI scripts (that can now be
removed)
- mainly a problem for building curl as it depends on other foreign cc
built dependences that are copied/linked into temp directories by
rules_foreign_cc