### PR TITLE
increase disk size for coverage

### DIFF
--- a/self-run-agents/instances/main.tf
+++ b/self-run-agents/instances/main.tf
@@ -10,7 +10,7 @@ module "x64-large-build-pool" {
   aws_account_id             = "457956385456"
   azp_pool_name              = "x64-large"
   azp_token                  = var.azp_token
-  disk_size_gb               = 200
+  disk_size_gb               = 500
   guaranteed_instances_count = 2
   instance_type              = "r5.4xlarge"
 


### PR DESCRIPTION
200GB wasn't enough for coverage multi-binary build:
https://dev.azure.com/cncf/envoy/_build/results?buildId=39545&view=logs&j=207fd6ff-0e51-50c6-c096-ea97a3fe6f94

Signed-off-by: Lizan Zhou <lizan@tetrate.io>