### PR TITLE
IAM fixes for instances to properly set-instance-protection

### DIFF
--- a/self-run-agents/instances/azp-build-asg/iam.tf
+++ b/self-run-agents/instances/azp-build-asg/iam.tf
@@ -8,7 +8,7 @@ data "aws_iam_policy_document" "asg_scale_in_protection" {
     ]
 
     resources = [
-      "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/${var.ami_prefix}_${var.azp_pool_name}_build_pool",
+      "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/${local.asg_name}",
     ]
   }
 }

--- a/self-run-agents/instances/azp-build-asg/init.sh.tpl
+++ b/self-run-agents/instances/azp-build-asg/init.sh.tpl
@@ -17,36 +17,43 @@ echo '#!/usr/bin/env bash
 
 mkdir -p /run/aws-protection-data/
 wget -q -O - http://169.254.169.254/latest/meta-data/identity-credentials/ec2/security-credentials/ec2-instance > /run/aws-protection-data/creds.json
+wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document > /run/aws-protection-data/iid.json
+echo -n "${asg_name}" > /run/aws-protection-data/asg-name
+
 chmod 0400 /run/aws-protection-data/creds.json
+chmod 0400 /run/aws-protection-data/iid.json
+chmod 0400 /run/aws-protection-data/asg-name
 chown azure-pipelines:azure-pipelines /run/aws-protection-data/creds.json
-' > /usr/local/bin/aws-token-refresh.sh
-chmod +x /usr/local/bin/aws-token-refresh.sh
+chown azure-pipelines:azure-pipelines /run/aws-protection-data/iid.json
+chown azure-pipelines:azure-pipelines /run/aws-protection-data/asg-name
+' > /usr/local/bin/aws-metadata-refresh.sh
+chmod +x /usr/local/bin/aws-metadata-refresh.sh
 
 echo "[Unit]
 Description=Refersh User Data Credentials for AZP
-Wants=aws-token-refresh.timer
+Wants=aws-metadata-refresh.timer
 
 [Service]
-ExecStart=/usr/local/bin/aws-token-refresh.sh
+ExecStart=/usr/local/bin/aws-metadata-refresh.sh
 User=root
 
 [Install]
-WantedBy=multi-user.target" > /lib/systemd/system/aws-token-refresh.service
+WantedBy=multi-user.target" > /lib/systemd/system/aws-metadata-refresh.service
 echo "[Unit]
 Description=Renew AWS Creds once every half hour
-Requires=aws-token-refresh.service
+Requires=aws-metadata-refresh.service
 
 [Timer]
-Unit=aws-token-refresh.service
+Unit=aws-metadata-refresh.service
 OnUnitInactiveSec=30m
 RandomizedDelaySec=30m
 
 [Install]
-WantedBy=timers.target" > /lib/systemd/system/aws-token-refresh.timer
+WantedBy=timers.target" > /lib/systemd/system/aws-metadata-refresh.timer
 systemctl daemon-reload
-systemctl enable aws-token-refresh.service aws-token-refresh.timer
-systemctl start aws-token-refresh.service aws-token-refresh.timer
-/usr/local/bin/aws-token-refresh.sh
+systemctl enable aws-metadata-refresh.service aws-metadata-refresh.timer
+systemctl start aws-metadata-refresh.service aws-metadata-refresh.timer
+/usr/local/bin/aws-metadata-refresh.sh
 
 # Block Azure Pipelines from Making Requests to Local Instance User Data.
 iface=$(ls /sys/class/net/ | grep -v lo | grep -v docker0)

--- a/self-run-agents/instances/azp-build-asg/init.sh.tpl
+++ b/self-run-agents/instances/azp-build-asg/init.sh.tpl
@@ -16,7 +16,9 @@ mkdir -p /usr/local/bin
 echo '#!/usr/bin/env bash
 
 mkdir -p /run/aws-protection-data/
-wget -q -O - http://169.254.169.254/latest/meta-data/identity-credentials/ec2/security-credentials/ec2-instance > /run/aws-protection-data/creds.json
+
+role_name=$(wget -q -O - http://169.254.169.254/latest/meta-data/iam/security-credentials)
+wget -q -O - "http://169.254.169.254/latest/meta-data/iam/security-credentials/$role_name" > /run/aws-protection-data/creds.json
 wget -q -O - http://169.254.169.254/latest/dynamic/instance-identity/document > /run/aws-protection-data/iid.json
 echo -n "${asg_name}" > /run/aws-protection-data/asg-name
 

--- a/self-run-agents/instances/azp-build-asg/init.sh.tpl
+++ b/self-run-agents/instances/azp-build-asg/init.sh.tpl
@@ -45,7 +45,8 @@ RandomizedDelaySec=30m
 WantedBy=timers.target" > /lib/systemd/system/aws-token-refresh.timer
 systemctl daemon-reload
 systemctl enable aws-token-refresh.service aws-token-refresh.timer
-
+systemctl start aws-token-refresh.service aws-token-refresh.timer
+/usr/local/bin/aws-token-refresh.sh
 
 # Block Azure Pipelines from Making Requests to Local Instance User Data.
 iface=$(ls /sys/class/net/ | grep -v lo | grep -v docker0)

--- a/self-run-agents/instances/azp-build-asg/instances.tf
+++ b/self-run-agents/instances/azp-build-asg/instances.tf
@@ -1,3 +1,7 @@
+locals {
+  asg_name = "${var.ami_prefix}_${var.azp_pool_name}_build_pool"
+}
+
 data "aws_ami" "azp_ci_image" {
   most_recent = true
   owners      = [var.aws_account_id]
@@ -16,6 +20,7 @@ data "aws_ami" "azp_ci_image" {
 data "template_file" "init" {
   template = file("${path.module}/init.sh.tpl")
   vars = {
+    asg_name      = local.asg_name
     azp_pool_name = var.azp_pool_name
     azp_token     = var.azp_token
   }
@@ -60,9 +65,8 @@ resource "aws_launch_template" "build_pool" {
   vpc_security_group_ids = ["sg-0e26fd7adddb1b9fa"]
 }
 
-
 resource "aws_autoscaling_group" "build_pool" {
-  name            = "${var.ami_prefix}_${var.azp_pool_name}_build_pool"
+  name            = "${local.asg_name}"
   placement_group = aws_placement_group.spread.id
 
   min_size         = var.guaranteed_instances_count


### PR DESCRIPTION
* Actually start the token refresh service `enable != start`
* Write ASG Name for targeting with instance protection.
* Write out region, so we know which region to call AWS for.
* Fetch the instance profile credentials and refresh those, rather the creds of the ec2 instance itself.