### PR TITLE
automatically cleanup old defunct AMIs

### DIFF
--- a/self-run-agents/instances/.gitignore
+++ b/self-run-agents/instances/.gitignore
@@ -1,2 +1,3 @@
 /.terraform
-/lambda.zip
+/lambda-dereg.zip
+/lambda-cleanup.zip

--- a/self-run-agents/instances/azp-build-asg/instances.tf
+++ b/self-run-agents/instances/azp-build-asg/instances.tf
@@ -66,7 +66,7 @@ resource "aws_launch_template" "build_pool" {
 }
 
 resource "aws_autoscaling_group" "build_pool" {
-  name            = "${local.asg_name}"
+  name            = local.asg_name
   placement_group = aws_placement_group.spread.id
 
   min_size         = var.guaranteed_instances_count

--- a/self-run-agents/instances/azp-cleanup-snapshots/.gitignore
+++ b/self-run-agents/instances/azp-cleanup-snapshots/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/self-run-agents/instances/azp-cleanup-snapshots/README.md
+++ b/self-run-agents/instances/azp-cleanup-snapshots/README.md
@@ -1,0 +1,8 @@
+# AZP Cleanup Snapshots #
+
+By default our AMI Building Tool "Packer", leaves around snapshots indefinitely
+along with the AMIs it builds. The goal of this lambda is to run every day,
+find any AMIs that aren't used, as well as snapshots, and delete them.
+
+This is just a cost savings measure even though snapshots are relatively cheap
+there is no reason to be paying for them.

--- a/self-run-agents/instances/azp-cleanup-snapshots/index.js
+++ b/self-run-agents/instances/azp-cleanup-snapshots/index.js
@@ -1,0 +1,235 @@
+const AWS = require('aws-sdk');
+const ec2 = new AWS.EC2();
+
+async function describeAmis() {
+  return await new Promise((resolve, reject) => {
+    ec2.describeImages(
+      {
+        Filters: [
+          {
+            Name: 'image-type',
+            Values: ['machine'],
+          },
+          {
+            Name: 'owner-id',
+            Values: ['457956385456'],
+          },
+          {
+            Name: 'state',
+            Values: ['available'],
+          },
+        ],
+      },
+      (err, data) => {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      },
+    );
+  });
+}
+
+function extractLatestTemplateFromList(launchTemplates) {
+  return launchTemplates
+    .sort((comp, compTwo) => {
+      if (comp.VersionNumber < compTwo.VersionNumber) {
+        return -1;
+      } else if (comp.VersionNumber > compTwo.VersionNumber) {
+        return 1;
+      } else {
+        return 0;
+      }
+    })
+    .slice(-1)[0];
+}
+
+async function latestLTVersionTailRec(launchTemplateId, nextToken = null) {
+  const data = await new Promise((resolve, reject) => {
+    ec2.describeLaunchTemplateVersions(
+      {
+        LaunchTemplateId: launchTemplateId,
+        NextToken: nextToken == null ? undefined : nextToken,
+      },
+      (err, data) => {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      },
+    );
+  });
+
+  if (data.NextToken != null && data.NextToken != '') {
+    return await latestLTVersionTailRec(launchTemplateId, data.NextToken);
+  } else {
+    return extractLatestTemplateFromList(data.LaunchTemplateVersions);
+  }
+}
+
+/**
+ * Determine if an AMI is the latest in a launch template.
+ *
+ * @param {String} imageId
+ *  The AMI ID to check on.
+ */
+async function amiIsUsedLatestTemplate(imageId) {
+  const launchTemplates = await new Promise((resolve, reject) => {
+    ec2.describeLaunchTemplates({}, (err, data) => {
+      if (err != null) {
+        reject(err);
+      } else {
+        resolve(data);
+      }
+    });
+  });
+
+  let isUsed = false;
+  let seenTemplates = [];
+  for (let template of launchTemplates.LaunchTemplates) {
+    if (seenTemplates.indexOf(template.LaunchTemplateId) == -1) {
+      let latestVersion = await latestLTVersionTailRec(
+        template.LaunchTemplateId,
+      );
+      if (latestVersion['LaunchTemplateData']['ImageId'] == imageId) {
+        isUsed = true;
+        return isUsed;
+      }
+      seenTemplates.push(template.LaunchTemplateId);
+    }
+  }
+  return isUsed;
+}
+
+/**
+ * Determine if an AMI is being used by an EC2 instance actively.
+ *
+ * @param {String} imageId
+ *  The AMI ID to check on.
+ */
+async function amiIsUsedInstance(imageId) {
+  const instances = await new Promise((resolve, reject) => {
+    ec2.describeInstances(
+      {
+        DryRun: false,
+        Filters: [
+          {
+            Name: 'image-id',
+            Values: [imageId],
+          },
+        ],
+        // We only need to know if 1 is in used, but the minimum is 5.
+        MaxResults: 5,
+      },
+      (err, data) => {
+        if (err != null) {
+          reject(err);
+        } else {
+          resolve(data);
+        }
+      },
+    );
+  });
+
+  return instances['Reservations'] != null && instances.Reservations.length > 0;
+}
+
+exports.handler = async function (_, context) {
+  try {
+    const amiResp = await describeAmis();
+
+    // Find all AZP AMIs.
+    const azpAmis = amiResp.Images.filter((image) => {
+      if (image['Tags'] == null) {
+        return false;
+      }
+
+      let has_envoy_project_tag = false;
+      image['Tags'].forEach((tagObj) => {
+        if (tagObj['Key'] != 'Project') {
+          return;
+        }
+        if (tagObj['Value'].indexOf('envoy-azp-') != 0) {
+          return;
+        }
+        has_envoy_project_tag = true;
+      });
+
+      return has_envoy_project_tag;
+    });
+
+    // Find all unused AZP AMIs.
+    let defunctAmis = [];
+    for (let amiObj of azpAmis) {
+      const amiID = amiObj.ImageId;
+
+      const isUsedInstance = await amiIsUsedInstance(amiID);
+      if (isUsedInstance) {
+        console.log('Found AMI being used by instances:', amiID);
+        continue;
+      }
+      const isUsedTemplates = await amiIsUsedLatestTemplate(amiID);
+      if (isUsedTemplates) {
+        console.log('Found AMI being used in the latest template:', amiID);
+        continue;
+      }
+
+      defunctAmis.push(amiObj);
+    }
+
+    // Delete AMIs + Snapshots.
+    for (let amiObj of defunctAmis) {
+      console.log('Found Defunct AMI: ', amiObj.ImageId);
+      const amiID = amiObj.ImageId;
+      const snapshotIDs = amiObj.BlockDeviceMappings.filter(
+        (bdm) => bdm['Ebs'] != null && bdm['Ebs']['SnapshotId'] != null,
+      ).map((bdm) => bdm.Ebs.SnapshotId);
+      console.log(
+        'Deleting AMI: ',
+        amiID,
+        ' and associated snapshot IDs: ',
+        snapshotIDs,
+      );
+
+      // Deregister the image.
+      await new Promise((resolve, reject) => {
+        ec2.deregisterImage(
+          {
+            ImageId: amiID,
+          },
+          (err) => {
+            if (err != null) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          },
+        );
+      });
+
+      for (let snapshotID of snapshotIDs) {
+        await new Promise((resolve, reject) => {
+          ec2.deleteSnapshot(
+            {
+              SnapshotId: snapshotID,
+            },
+            (err) => {
+              if (err != null) {
+                reject(err);
+              } else {
+                resolve();
+              }
+            },
+          );
+        });
+      }
+    }
+
+    context.succeed();
+  } catch (error) {
+    console.log('Failed to Cleanup AMIs: ', error, error.stack);
+    context.fail();
+  }
+};

--- a/self-run-agents/instances/azp-cleanup-snapshots/package-lock.json
+++ b/self-run-agents/instances/azp-cleanup-snapshots/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "azp-cleanup-snapshots",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "prettier": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "dev": true
+    }
+  }
+}

--- a/self-run-agents/instances/azp-cleanup-snapshots/package.json
+++ b/self-run-agents/instances/azp-cleanup-snapshots/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "azp-cleanup-snapshots",
+  "version": "1.0.0",
+  "description": "An Lambda that cleans up snapshots within AWS that were built for AZP.",
+  "main": "index.js",
+  "scripts": {
+    "format": "prettier --single-quote --trailing-comma all --write '*.js'",
+    "lint": "prettier --single-quote --trailing-comma all --check '*.js'",
+    "build": "rm -rf ./node_modules/ && npm install --production && zip -r ../lambda-cleanup.zip ."
+  },
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "prettier": "^2.0.5"
+  }
+}

--- a/self-run-agents/instances/azp-dereg-lambda/package.json
+++ b/self-run-agents/instances/azp-dereg-lambda/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "format": "prettier --single-quote --trailing-comma all --write '*.js'",
     "lint": "prettier --single-quote --trailing-comma all --check '*.js'",
-    "build": "rm -rf ./node_modules/ && npm install --production && zip -r ../lambda.zip ."
+    "build": "rm -rf ./node_modules/ && npm install --production && zip -r ../lambda-dereg.zip ."
   },
   "license": "MIT",
   "dependencies": {

--- a/self-run-agents/instances/cloudwatch.tf
+++ b/self-run-agents/instances/cloudwatch.tf
@@ -1,0 +1,19 @@
+resource "aws_cloudwatch_event_rule" "every_day" {
+  name = "every-day"
+  description = "Fires once every day"
+  schedule_expression = "rate(1 day)"
+}
+
+resource "aws_cloudwatch_event_target" "cleanup_every_day" {
+  rule = aws_cloudwatch_event_rule.every_day.name
+  target_id = "cleanup_amis_daily"
+  arn = aws_lambda_function.cleanup_lambda.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_check_foo" {
+  statement_id = "AllowExecutionFromCloudWatch"
+  action = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cleanup_lambda.function_name
+  principal = "events.amazonaws.com"
+  source_arn = aws_cloudwatch_event_rule.every_day.arn
+}

--- a/self-run-agents/instances/iam.tf
+++ b/self-run-agents/instances/iam.tf
@@ -58,6 +58,45 @@ resource "aws_iam_role_policy" "ec2_perms" {
 }
 
 #########################################################################################
+# Permissions for the Cleanup Lambda.                                                   #
+#########################################################################################
+
+data "aws_iam_policy_document" "lambda_cleanup_ami_permissions" {
+  statement {
+    actions = [
+      # Allow it to describe things in EC2 to not only describe the AMIs
+      # but also find all places they're being used.
+      "ec2:Describe*",
+      # Allow it to deregister an AMI so it can't be used anymore.
+      "ec2:DeregisterImage",
+      # Allow it to delete the snapshot of the AMI.
+      "ec2:DeleteSnapshot",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cleanup_lambda_role" {
+  name               = "ami_cleanup_lambda_role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "log_perms_cleanup" {
+  name = "ami_cleanup_lambda_log_perms"
+  role = aws_iam_role.cleanup_lambda_role.id
+
+  policy = data.aws_iam_policy_document.lambda_logs.json
+}
+
+resource "aws_iam_role_policy" "cleanup_ec2_perms" {
+  name = "ami_cleanup_lambda_ec2_perms"
+  role = aws_iam_role.cleanup_lambda_role.id
+
+  policy = data.aws_iam_policy_document.lambda_cleanup_ami_permissions.json
+}
+
+#########################################################################################
 # Permissions for the ASGs to publish to the SNS Topic                                  #
 #########################################################################################
 

--- a/self-run-agents/instances/lambda.tf
+++ b/self-run-agents/instances/lambda.tf
@@ -1,5 +1,5 @@
-resource "aws_lambda_function" "test_lambda" {
-  filename      = "lambda.zip"
+resource "aws_lambda_function" "dereg_lambda" {
+  filename      = "lambda-dereg.zip"
   function_name = "azp_dereg_lambda"
   role          = aws_iam_role.lambda_role.arn
   handler       = "index.handler"
@@ -8,7 +8,7 @@ resource "aws_lambda_function" "test_lambda" {
   memory_size = 512
   timeout     = 180
 
-  source_code_hash = filebase64sha256("lambda.zip")
+  source_code_hash = filebase64sha256("lambda-dereg.zip")
 
   environment {
     variables = {
@@ -18,16 +18,29 @@ resource "aws_lambda_function" "test_lambda" {
   }
 }
 
+resource "aws_lambda_function" "cleanup_lambda" {
+  filename      = "lambda-cleanup.zip"
+  function_name = "ami_cleanup_lambda"
+  role          = aws_iam_role.cleanup_lambda_role.arn
+  handler       = "index.handler"
+  runtime       = "nodejs12.x"
+
+  memory_size = 512
+  timeout     = 180
+
+  source_code_hash = filebase64sha256("lambda-cleanup.zip")
+}
+
 resource "aws_sns_topic_subscription" "lambda_to_sns" {
   topic_arn = aws_sns_topic.lifecycle_updates.arn
   protocol  = "lambda"
-  endpoint  = aws_lambda_function.test_lambda.arn
+  endpoint  = aws_lambda_function.dereg_lambda.arn
 }
 
 resource "aws_lambda_permission" "allow_sns" {
   statement_id  = "AllowExecutionFromSns"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.test_lambda.function_name
+  function_name = aws_lambda_function.dereg_lambda.function_name
   principal     = "sns.amazonaws.com"
   source_arn    = aws_sns_topic.lifecycle_updates.arn
 }


### PR DESCRIPTION
automatically clear our old defunct AMIs that are no longer being
used. this running once a day should give us plenty of room for
rollbacks as those can be executed quickly <10 minutes.

this is not only a cost saving measure, but also makes it much easier
to reason about the state of the world.