### PR TITLE
bump disk size for coverage pool

### DIFF
--- a/self-run-agents/instances/main.tf
+++ b/self-run-agents/instances/main.tf
@@ -10,7 +10,7 @@ module "x64-large-build-pool" {
   aws_account_id             = "457956385456"
   azp_pool_name              = "x64-large"
   azp_token                  = var.azp_token
-  disk_size_gb               = 500
+  disk_size_gb               = 2000
   guaranteed_instances_count = 2
   instance_type              = "r5.4xlarge"
 


### PR DESCRIPTION
disk space is cheap, failed builds are not

Signed-off-by: Cynthia <cynthia@coan.dev>