### PR TITLE
Override temp path env variables to keep within 8.3 name convention

### DIFF
--- a/build_container/Dockerfile-windows2019
+++ b/build_container/Dockerfile-windows2019
@@ -2,7 +2,9 @@ FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 ENV MSYS2_ARG_CONV_EXCL "*"
 
-ENV TMPDIR C:\\Users\\ContainerAdministrator\\AppData\\Local\\Temp
+ENV TMPDIR C:\\Windows\\Temp
+ENV TMP C:\\Windows\\Temp
+ENV TEMP C:\\Windows\\Temp
 
 # Ensures paths rooted at /c/ can be found by programs running via msys2 shell
 RUN cmd.exe /c "mklink /D C:\c C:\"

--- a/self-run-agents/instances/main.tf
+++ b/self-run-agents/instances/main.tf
@@ -10,7 +10,7 @@ module "x64-large-build-pool" {
   aws_account_id             = "457956385456"
   azp_pool_name              = "x64-large"
   azp_token                  = var.azp_token
-  disk_size_gb               = 500
+  disk_size_gb               = 2000
   guaranteed_instances_count = 2
   instance_type              = "r5.4xlarge"
 


### PR DESCRIPTION
Otherwise bazel can pick up a shortened path that is no longer required
to be supported on NTFS

Also fixes centos image build to not try to re symlink Ninja

We see failures in CI using the Windows toolchain that may be related: https://dev.azure.com/cncf/envoy/_build/results?buildId=40637&view=logs&j=2d2b3007-3c5c-5840-9bb0-2b1ea49925f3&t=168f295b-0553-5364-35f7-923225ecd8b3&l=104