### PR TITLE
Windows image: No longer install git via msys2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
         OS_DISTRO: windows2019
         PUSH_GCR_IMAGE: true
         GCR_IMAGE_NAME: envoy-build-windows
-  dependsOn: "generate_toolchains_linux"
+  dependsOn: []
   pool:
     vmImage: 'windows-latest'
   steps:
@@ -80,7 +80,7 @@ jobs:
       GCP_SERVICE_ACCOUNT_KEY: $(GcpServiceAccountKey)
 
 - job: generate_toolchains_windows
-  dependsOn: "build_container_windows"
+  dependsOn: ["build_container_windows", "generate_toolchains_linux"]
   pool:
     vmImage: 'windows-latest'
   steps:

--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -133,8 +133,15 @@ RunAndCheckError "pacman.exe" @("-Syy", "--noconfirm")
 # RunAndCheckError "pacman.exe" @("-Suu", "--noconfirm")
 # Update remaining packages (and package db refresh in case previous step requires it)
 # RunAndCheckError "pacman.exe" @("-Syu", "--noconfirm")
-RunAndCheckError "pacman.exe" @("-S", "--noconfirm", "--needed", "diffutils", "git", "patch", "unzip", "zip")
+RunAndCheckError "pacman.exe" @("-S", "--noconfirm", "--needed", "diffutils", "patch", "unzip", "zip")
 RunAndCheckError "pacman.exe" @("-Scc", "--noconfirm")
+
+# Git
+DownloadAndCheck $env:TEMP\git-setup.exe `
+                 https://github.com/git-for-windows/git/releases/download/v2.26.2.windows.1/Git-2.26.2-64-bit.exe `
+                 cdf76510979dace4d3f5368e2f55d4289c405e249399e7ed09049765489da6e8
+RunAndCheckError "$env:TEMP\git-setup.exe" @("/SILENT") $true
+AddToPath $env:ProgramFiles\Git\bin
 
 echo "Cleaning up temporary files..."
 rm -Recurse -Force $env:TEMP\*


### PR DESCRIPTION
- It brings in extra dependencies which fail to install
- Rather than fighting msys2, install from the project itself
- Also parallelize image build steps