### PR TITLE
Windows image: Update PATH to handle bumped versions of VS Build Tools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ jobs:
         OS_DISTRO: centos
         PUSH_GCR_IMAGE: false
   dependsOn: []
+  timeoutInMinutes: 120
   pool:
     vmImage: 'ubuntu-18.04'
   steps:

--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -49,5 +49,3 @@ if [[ $(uname -m) == "aarch64" ]] && grep -q -e rhel /etc/*-release ; then
 fi
 
 source ./build_container_common.sh
-
-yum clean all

--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -49,3 +49,5 @@ if [[ $(uname -m) == "aarch64" ]] && grep -q -e rhel /etc/*-release ; then
 fi
 
 source ./build_container_common.sh
+
+yum clean all

--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -72,7 +72,7 @@ echo @"
 }
 "@ > $env:TEMP\vs_buildtools_config
 RunAndCheckError "cmd.exe" $("/s", "/c", "$env:TEMP\vs_buildtools.exe --addProductLang en-US --quiet --wait --norestart --nocache --config $env:TEMP\vs_buildtools_config")
-AddToPath "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.25.28610\bin\Hostx64\x64"
+AddToPath (Resolve-Path "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\*\bin\Hostx64\x64").Path
 
 # CMake (to ensure a 64-bit build of the tool, VS BuildTools ships a 32-bit build)
 DownloadAndCheck $env:TEMP\cmake.msi `


### PR DESCRIPTION
- Ensure PATH is updated with the path to cl.exe and link.exe of the installed version of VS build tools, no longer hard code paths
- Do a yum clean all to remove cache, this was mostly an effort to ensure an image rebuild
- The ubuntu image build and push is taking over an hour so bump the timeout of the linux build to 2 hours