### PR TITLE
agent: setup S3 cache proxy

### DIFF
--- a/self-run-agents/ami-build/scripts/install-bazel-remote.sh
+++ b/self-run-agents/ami-build/scripts/install-bazel-remote.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+export GOARCH=$(dpkg --print-architecture)
+
+BUILD_TMP="$(mktemp -d)"
+trap "chmod +w -R ${BUILD_TMP} && rm -rf ${BUILD_TMP}" EXIT
+
+cd "${BUILD_TMP}"
+
+curl -fsSL https://golang.org/dl/go1.14.5.linux-${GOARCH}.tar.gz | tar zx
+export GOPATH="${BUILD_TMP}/gopath"
+
+git clone https://github.com/buchgr/bazel-remote
+cd bazel-remote
+PATH="${BUILD_TMP}/go/bin:${PATH}" ./linux-build.sh
+sudo cp ./bazel-remote /usr/local/bin/bazel-remote

--- a/self-run-agents/instances/azp-build-asg/iam.tf
+++ b/self-run-agents/instances/azp-build-asg/iam.tf
@@ -1,6 +1,4 @@
-# Creates an IAM Role where instances themselves can then set instance
-# protection on themselves.
-
+# Creates an IAM Role where instances themselves can then detach themselves from ASG.
 data "aws_iam_policy_document" "asg_detach_instances" {
   statement {
     actions = [
@@ -9,6 +7,31 @@ data "aws_iam_policy_document" "asg_detach_instances" {
 
     resources = [
       "arn:aws:autoscaling:*:${var.aws_account_id}:autoScalingGroup:*:autoScalingGroupName/${local.asg_name}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bazel_cache_bucket}",
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+
+      values = [
+        "${var.cache_prefix}/*",
+      ]
+    }
+  }
+  statement {
+    actions = [
+      "s3:*Object"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.bazel_cache_bucket}/${var.cache_prefix}/*",
     ]
   }
 }
@@ -38,4 +61,70 @@ resource "aws_iam_role_policy" "asg_iam_role_policy" {
 resource "aws_iam_instance_profile" "asg_iam_instance_profile" {
   name = "${var.ami_prefix}_${var.azp_pool_name}_IProfile"
   role = aws_iam_role.asg_iam_role.name
+}
+
+# Creates an IAM Role where instances can get token and associate with running IAM profile.
+data "aws_iam_policy_document" "init_permissions" {
+  statement {
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "arn:aws:s3:::cncf-envoy-token/azp_token",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:ReplaceIamInstanceProfileAssociation"
+    ]
+
+    resources = [
+      "*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ARN"
+      values   = ["$${ec2:SourceInstanceARN}"]
+    }
+  }
+
+  statement {
+    actions = [
+      "iam:PassRole"
+    ]
+
+    resources = [
+      aws_iam_role.asg_iam_role.arn
+    ]
+  }
+
+  statement {
+    actions = [
+      "ec2:DescribeIamInstanceProfileAssociations"
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+
+}
+
+resource "aws_iam_role" "asg_init_iam_role" {
+  name               = "${var.ami_prefix}_${var.azp_pool_name}_init_IAMRole"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "asg_init_iam_role_policy" {
+  name   = "${var.ami_prefix}_${var.azp_pool_name}_init_IAMRolePolicy"
+  role   = aws_iam_role.asg_init_iam_role.id
+  policy = data.aws_iam_policy_document.init_permissions.json
+}
+
+resource "aws_iam_instance_profile" "asg_init_iam_instance_profile" {
+  name = "${var.ami_prefix}_${var.azp_pool_name}_init_IProfile"
+  role = aws_iam_role.asg_init_iam_role.name
 }

--- a/self-run-agents/instances/azp-build-asg/init.sh.tpl
+++ b/self-run-agents/instances/azp-build-asg/init.sh.tpl
@@ -1,34 +1,58 @@
 #!/usr/bin/env bash
 
-# Hostname shows in AZP side, use Instance ID Rather than a public ip.
-instance_id=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
-echo "$instance_id" > /etc/hostname
-echo "127.0.1.1 $instance_id" >> /etc/hosts
-hostname "$instance_id"
+set -e
 
-mkdir -p /run/aws-metadata/
-echo -n "${asg_name}" > /run/aws-metadata/asg-name
-/usr/local/bin/aws-metadata-refresh.sh
-
-# Configure Azure Pipelines Agent, this has to be done at runtime since
-# it will show up in the UI once we configure.
-sudo -u azure-pipelines /bin/bash -c 'cd /srv/azure-pipelines && ./config.sh --unattended --acceptteeeula --url https://dev.azure.com/cncf/ --pool ${azp_pool_name} --token ${azp_token}'
-sudo -u azure-pipelines mkdir /srv/azure-pipelines/_work
-
-# Block Azure Pipelines from Making Requests to Local Instance User Data.
-iptables -A OUTPUT -d 169.254.169.254 -m owner ! --uid-owner root -j DROP
-iptables -A OUTPUT -s 169.254.169.254 -m owner ! --uid-owner root -j DROP
-iptables -I DOCKER-USER -s 169.254.169.254 -j DROP
-iptables -I DOCKER-USER -d 169.254.169.254 -j DROP
-
-# Start AZP Agent.
 function terminate {
     # Terminate instances in 1 min
     shutdown -h +1
 }
 trap terminate EXIT
 
-# This is a hook to be run when a job starts
-(inotifywait /srv/azure-pipelines/_work -e CREATE && /usr/local/bin/detach-self.sh || true) &
+# Hostname shows in AZP side, use Instance ID Rather than a public ip.
+instance_id=$(wget -q -O - http://169.254.169.254/latest/meta-data/instance-id)
+echo "127.0.1.1 $instance_id" >> /etc/hosts
+hostnamectl set-hostname "$instance_id"
 
+azp_token=$(aws s3 cp s3://cncf-envoy-token/azp_token -)
+
+export AWS_DEFAULT_REGION=us-east-1
+aws ec2 replace-iam-instance-profile-association --iam-instance-profile Arn=${instance_profile_arn} \
+  --association-id $(aws ec2 describe-iam-instance-profile-associations --filter=Name=instance-id,Values=$instance_id | jq -r '.IamInstanceProfileAssociations[0].AssociationId')
+
+# Configure Azure Pipelines Agent, this has to be done at runtime since
+# it will show up in the UI once we configure.
+sudo -u azure-pipelines /bin/bash -c "cd /srv/azure-pipelines && ./config.sh --unattended --acceptteeeula --url https://dev.azure.com/cncf/ --pool ${azp_pool_name} --token $azp_token"
+sudo -u azure-pipelines mkdir /srv/azure-pipelines/_work
+
+# Clear credential cache and verify we're in right role before starting agent
+unset azp_token
+rm -rf ~/.aws
+aws sts get-caller-identity | jq -r '.Arn' | grep -o "/${role_name}/"
+
+# Setup bazel remote cache S3 proxy
+echo "
+[Unit]
+Description=Bazel Remote Cache Service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=bazel-remote
+ExecStart=/usr/local/bin/bazel-remote --s3.endpoint s3.us-east-1.amazonaws.com --s3.bucket ${bazel_cache_bucket} --s3.prefix ${cache_prefix} --s3.iam_role_endpoint http://169.254.169.254 --max_size 30 --dir /dev/shm/bazel-remote-cache
+
+[Install]
+WantedBy=multi-user.target
+" > /etc/systemd/system/bazel-remote.service
+
+systemctl daemon-reload
+systemctl enable bazel-remote
+systemctl start bazel-remote
+
+# This is a hook to be run when a job starts
+(inotifywait /srv/azure-pipelines/_work -e CREATE && aws autoscaling detach-instances --instance-ids $instance_id --auto-scaling-group-name ${asg_name} --no-should-decrement-desired-capacity || true) &
+
+# Start AZP Agent.
 sudo -u azure-pipelines /bin/bash -c 'cd /srv/azure-pipelines && ./run.sh --once'

--- a/self-run-agents/instances/azp-build-asg/inputs.tf
+++ b/self-run-agents/instances/azp-build-asg/inputs.tf
@@ -9,3 +9,5 @@ variable "on_demand_instances_count" {
 }
 variable "idle_instances_count" { type = number }
 variable "instance_type" { type = string }
+variable "bazel_cache_bucket" { type = string }
+variable "cache_prefix" { type = string }

--- a/self-run-agents/instances/main.tf
+++ b/self-run-agents/instances/main.tf
@@ -13,6 +13,8 @@ module "x64-large-build-pool" {
   disk_size_gb         = 2000
   idle_instances_count = 1
   instance_type        = "r5.8xlarge"
+  bazel_cache_bucket   = aws_s3_bucket.build-cache.bucket
+  cache_prefix         = "public-x64"
 
   providers = {
     aws = aws
@@ -26,9 +28,11 @@ module "arm-build-pool" {
   aws_account_id       = "457956385456"
   azp_pool_name        = "arm-large"
   azp_token            = var.azp_token
-  disk_size_gb         = 500
+  disk_size_gb         = 1000
   idle_instances_count = 1
-  instance_type        = "r6g.2xlarge"
+  instance_type        = "r6g.4xlarge"
+  bazel_cache_bucket   = aws_s3_bucket.build-cache.bucket
+  cache_prefix         = "public-arm64"
 
   providers = {
     aws = aws

--- a/self-run-agents/instances/s3.tf
+++ b/self-run-agents/instances/s3.tf
@@ -1,0 +1,27 @@
+resource "aws_s3_bucket" "token" {
+  bucket = "cncf-envoy-token"
+  acl    = "private"
+
+  tags = {
+    Environment = "Production"
+  }
+}
+
+resource "aws_s3_bucket" "build-cache" {
+  bucket = "envoy-ci-build-cache"
+  acl    = "private"
+
+  tags = {
+    Environment = "Production"
+  }
+
+  lifecycle_rule {
+    id      = "all"
+    enabled = true
+    prefix  = ""
+
+    expiration {
+      days = 10
+    }
+  }
+}

--- a/self-run-agents/instances/vpc.tf
+++ b/self-run-agents/instances/vpc.tf
@@ -1,0 +1,17 @@
+data "aws_vpc" "default" {
+  id = "vpc-419e9d3b"
+}
+
+data "aws_route_table" "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id       = data.aws_vpc.default.id
+  service_name = "com.amazonaws.us-east-1.s3"
+}
+
+resource "aws_vpc_endpoint_route_table_association" "private_s3" {
+  vpc_endpoint_id = aws_vpc_endpoint.s3.id
+  route_table_id  = data.aws_route_table.default.id
+}


### PR DESCRIPTION
- use init IAM role to setup agent and then switch to role has access to S3 cache.
- setup bazel-remote cache proxy for S3 on localhost

Signed-off-by: Lizan Zhou <lizan@tetrate.io>