### PR TITLE
add pcap group as system group

### DIFF
--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -35,7 +35,7 @@ echo "/opt/rh/httpd24/root/usr/lib64" > /etc/ld.so.conf.d/httpd24.conf
 ldconfig
 
 # Setup tcpdump for non-root.
-groupadd pcap
+groupadd -r pcap
 chgrp pcap /usr/sbin/tcpdump
 chmod 750 /usr/sbin/tcpdump
 setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -89,7 +89,7 @@ apt-get install -y aspell
 rm -rf /var/lib/apt/lists/*
 
 # Setup tcpdump for non-root.
-groupadd pcap
+groupadd -r pcap
 chgrp pcap /usr/sbin/tcpdump
 chmod 750 /usr/sbin/tcpdump
 setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump


### PR DESCRIPTION
having `pcap` group as GID 1000 leading to conflicts to workaround in devcontainer, it also break docker-sandbox.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>