### PR TITLE
update bazel to 3.4.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "bazel_toolchains",
-    sha256 = "2431088b38fd8e2878db17e3c5babb431de9e5c52b6d8b509d3070fa279a5be2",
-    strip_prefix = "bazel-toolchains-3.3.1",
-    urls = ["https://github.com/bazelbuild/bazel-toolchains/releases/download/3.3.1/bazel-toolchains-3.3.1.tar.gz"],
+    sha256 = "882fecfc88d3dc528f5c5681d95d730e213e39099abff2e637688a91a9619395",
+    strip_prefix = "bazel-toolchains-3.4.0",
+    urls = ["https://github.com/bazelbuild/bazel-toolchains/releases/download/3.4.0/bazel-toolchains-3.4.0.tar.gz"],
 )
 
 load(

--- a/toolchains/regenerate.sh
+++ b/toolchains/regenerate.sh
@@ -38,7 +38,7 @@ esac
 
 # Bazel query is the right command so bazel won't fail itself.
 # Keep bazel versions here at most two: current master version, next version
-for BAZEL_VERSION in "3.1.0" "3.3.1"; do
+for BAZEL_VERSION in "3.3.1" "3.4.1"; do
   for RBE_BAZEL_TARGET in ${RBE_BAZEL_TARGET_LIST}; do
     USE_BAZEL_VERSION="${BAZEL_VERSION}" bazel query ${BAZEL_QUERY_OPTIONS} ${RBE_BAZEL_TARGET}
   done


### PR DESCRIPTION
Note that Bazel's toolchain for 3.4.1 is tagged 3.4.0: https://github.com/bazelbuild/bazel-toolchains/releases/tag/3.4.0

Unblocking https://github.com/envoyproxy/envoy/pull/12123

Signed-off-by: Michael Rebello <me@michaelrebello.com>
