### PR TITLE
Add llvm 10 and nasm to Windows build image

### DIFF
--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -98,6 +98,21 @@ DownloadAndCheck $env:TEMP\ninja.zip `
 Expand-Archive -Path $env:TEMP\ninja.zip -DestinationPath C:\tools\ninja
 AddToPath C:\tools\ninja
 
+# LLVM
+DownloadAndCheck $env:TEMP\LLVM-win64.exe `
+                 https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe `
+                 893f8a12506f8ad29ca464d868fb432fdadd782786a10655b86575fc7fc1a562
+RunAndCheckError $env:TEMP\LLVM-win64.exe @("/S") $true
+AddToPath $env:ProgramFiles\LLVM\bin
+
+# NASM
+$nasmVersion = "2.15.03"
+DownloadAndCheck $env:TEMP\nasm-win64.zip `
+                 https://www.nasm.us/pub/nasm/releasebuilds/$nasmVersion/win64/nasm-$nasmVersion-win64.zip `
+                 e598d1a9c98345f8436750f42d1f7c5d75ba739919eef37cd9ae8406e6a38802
+Expand-Archive -Path $env:TEMP\nasm-win64.zip -DestinationPath C:\tools\
+AddToPath C:\tools\nasm-$nasmVersion
+
 # Python3 (do not install via msys2, that version behaves like posix)
 DownloadAndCheck $env:TEMP\python3-installer.exe `
                  https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe `

--- a/toolchains/rbe_toolchains_config.bzl
+++ b/toolchains/rbe_toolchains_config.bzl
@@ -44,6 +44,8 @@ _GCC_ENV = {
 
 _MSVC_CL_ENV = {}
 
+_CLANG_CL_ENV = {}
+
 _TOOLCHAIN_CONFIG_SUITE_SPEC_LINUX = {
     "container_registry": _ENVOY_BUILD_IMAGE_REGISTRY,
     "container_repo": _ENVOY_BUILD_IMAGE_REPOSITORY_LINUX,
@@ -98,3 +100,4 @@ def rbe_toolchains_config(generator = False, force = False):
     _envoy_rbe_toolchain("rbe_ubuntu_clang_libcxx", _CLANG_LIBCXX_ENV, "clang_libcxx", _TOOLCHAIN_CONFIG_SUITE_SPEC_LINUX, _ENVOY_BUILD_IMAGE_DIGEST_LINUX, linux_exec_properties, generator, force)
     _envoy_rbe_toolchain("rbe_ubuntu_gcc", _GCC_ENV, "gcc", _TOOLCHAIN_CONFIG_SUITE_SPEC_LINUX, _ENVOY_BUILD_IMAGE_DIGEST_LINUX, linux_exec_properties, generator, force)
     _envoy_rbe_toolchain("rbe_windows_msvc_cl", _MSVC_CL_ENV, "msvc-cl", _TOOLCHAIN_CONFIG_SUITE_SPEC_WINDOWS, _ENVOY_BUILD_IMAGE_DIGEST_WINDOWS, {}, generator, force)
+    _envoy_rbe_toolchain("rbe_windows_clang_cl", _CLANG_CL_ENV, "clang-cl", _TOOLCHAIN_CONFIG_SUITE_SPEC_WINDOWS, _ENVOY_BUILD_IMAGE_DIGEST_WINDOWS, {}, generator, force)

--- a/toolchains/regenerate.sh
+++ b/toolchains/regenerate.sh
@@ -32,7 +32,7 @@ case ${OS_FAMILY} in
     RBE_BAZEL_TARGET_LIST="@rbe_ubuntu_clang_gen//... @rbe_ubuntu_clang_libcxx_gen//... @rbe_ubuntu_gcc_gen//..."
     ;;
   windows)
-    RBE_BAZEL_TARGET_LIST="@rbe_windows_msvc_cl_gen//..."
+    RBE_BAZEL_TARGET_LIST="@rbe_windows_msvc_cl_gen//... @rbe_windows_clang_cl_gen//..."
     ;;
 esac
 


### PR DESCRIPTION
Also starts the base of the clang-cl toolchain config, may need to add additional environment variables in the future to ensure the clang-cl toolchain config uses the correct compilation tools