### PR TITLE
Set USE_CLANG_CL=1 to force substitute llvm tools

### DIFF
--- a/toolchains/rbe_toolchains_config.bzl
+++ b/toolchains/rbe_toolchains_config.bzl
@@ -44,7 +44,9 @@ _GCC_ENV = {
 
 _MSVC_CL_ENV = {}
 
-_CLANG_CL_ENV = {}
+_CLANG_CL_ENV = {
+    "USE_CLANG_CL": "1",
+}
 
 _TOOLCHAIN_CONFIG_SUITE_SPEC_LINUX = {
     "container_registry": _ENVOY_BUILD_IMAGE_REGISTRY,


### PR DESCRIPTION
It seems bazel-toolchains does not as of yet let us choose the actual
compiler we are targeting so the cc-compiler-x64_windows always points
to msvc-cl while on Linux, cc-compiler-k8 points to the correct compiler
(gcc or clang etc.).

With this change, we are in fact still using the compiler named msvc-cl
but the toolchain config points to llvm tools rather than MSVC tools.
The MSVC cl.exe and link.exe command syntax is what is common.

We may be able to undo this in the future if either Bazel itself is able to change its
CC toolchain rules for Windows to match the better Linux pattern (and do
away with the USE_CLANG_CL logic) or bazel-toolchains has a good way of
specifying a target cpu and compiler (so we can for example specify
x64_windows and clang-cl or x64_windows and msvc-cl to get the correct
toolchain).