### PR TITLE
Add shellcheck to envoy-build-ubuntu container

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -85,7 +85,8 @@ case $ARCH in
         ;;
 esac
 
-apt-get install -y aspell
+# additional apt installs
+apt-get install -y aspell shellcheck
 rm -rf /var/lib/apt/lists/*
 
 # Setup tcpdump for non-root.


### PR DESCRIPTION
Adds shellcheck to container to allow testing in ci - ref https://github.com/envoyproxy/envoy/pull/12871#discussion_r479996668

Signed-off-by: Ryan Northey <ryan@synca.io>