### PR TITLE
Windows build container: Disable unneeded services

### DIFF
--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -59,7 +59,6 @@ DisableService LanmanWorkstation
 DisableService MSDTC
 DisableService SysMain
 DisableService usosvc
-DisableService WinHttpAutoProxySvc
 DisableService WinRM
 
 # Ensures paths rooted at /c/ can be found by programs running via msys2 shell

--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -45,6 +45,23 @@ function RunAndCheckError
     echo "done."
 }
 
+function DisableService
+{
+    param([string] $serviceName)
+
+    echo "Disabling service '$serviceName'"
+    Set-Service -Name $serviceName -StartupType Disabled
+    Stop-Service -Force -Name $serviceName
+}
+
+DisableService DiagTrack
+DisableService LanmanWorkstation
+DisableService MSDTC
+DisableService SysMain
+DisableService usosvc
+DisableService WinHttpAutoProxySvc
+DisableService WinRM
+
 # Ensures paths rooted at /c/ can be found by programs running via msys2 shell
 RunAndCheckError "cmd.exe" @("/s", "/c", "mklink /D C:\c C:\")
 


### PR DESCRIPTION
Primary motivation is to ensure Windows update service is not running, may be source of some flakiness we have seen.

Disables services running by default in Windows Server Core container:
- DiagTrack
- LanmanWorkstation
- MSDTC
- SysMain
- usosvc (update orchestrator service)
- WinRM (windows remote management)