### PR TITLE
shellcheck: Update to v0.7.0

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -86,8 +86,17 @@ case $ARCH in
 esac
 
 # additional apt installs
-apt-get install -y aspell shellcheck
+apt-get install -y aspell
 rm -rf /var/lib/apt/lists/*
+
+# upstream install of shellcheck (taken from https://askubuntu.com/a/1228181)
+pushd /tmp || exit 1
+echo "c37d4f51e26ec8ab96b03d84af8c050548d7288a47f755ffb57706c6c458e027  /tmp/shellcheck-v0.7.0/shellcheck" > sc.checksum
+wget -qO- https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz | tar -xJf -
+sha256sum -c sc.checksum
+sudo cp shellcheck-v0.7.0/shellcheck /usr/local/bin
+rm -rf shellcheck-v0.7.0/ sc.checksum
+popd || exit 1
 
 # Setup tcpdump for non-root.
 groupadd -r pcap


### PR DESCRIPTION
fixes envoyproxy/envoy#13228

im noticing that the last PR i created - some rebuilding needs to happen to images - not sure what - but i can update if someone lmk

also, when this lands it will break (current) master i think, as there are some lint fails that are not currently being caught - im happy to fix these as/before this lands