### PR TITLE
Add CODEOWNERS file for PR auto review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# TODO: determine how we want to deal with auto-assignment
+# By default, @envoyproxy/maintainers own everything.
+# *       @envoyproxy/maintainers
+
+# Windows build container config
+/build_container/*windows* @envoyproxy/windows-dev


### PR DESCRIPTION
Adds `windows-dev` team as owners of Windows build container files

TODO/question for reviewer, which team or individuals to assign default review capacity? Linked issue suggests we might want to add a new team in GitHub

Closes https://github.com/envoyproxy/envoy-build-tools/issues/102