### PR TITLE
Update CODEOWNERS to build-tools-maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # By default, @envoyproxy/build-tools-maintainers own everything.
-*       @envoyproxy/build-tools-maintainers @envoyproxy/dependency-shepherds
+* @envoyproxy/build-tools-maintainers @envoyproxy/dependency-shepherds
 
 # Windows build container config
 /build_container/*windows* @envoyproxy/windows-dev

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,5 @@
-# TODO: determine how we want to deal with auto-assignment
-# By default, @envoyproxy/maintainers own everything.
-# *       @envoyproxy/maintainers
+# By default, @envoyproxy/build-tools-maintainers own everything.
+*       @envoyproxy/build-tools-maintainers
 
 # Windows build container config
 /build_container/*windows* @envoyproxy/windows-dev

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # By default, @envoyproxy/build-tools-maintainers own everything.
-*       @envoyproxy/build-tools-maintainers
+*       @envoyproxy/build-tools-maintainers @envoyproxy/dependency-shepherds
 
 # Windows build container config
 /build_container/*windows* @envoyproxy/windows-dev


### PR DESCRIPTION
Adds https://github.com/orgs/envoyproxy/teams/build-tools-maintainers and https://github.com/orgs/envoyproxy/teams/dependency-shepherds as owners of whole repo