### PR TITLE
Fix cmake-data dependency issue

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -44,9 +44,50 @@ apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
 
 apt-get update -y
 
-apt-get install -y --no-install-recommends docker-ce-cli wget make cmake git python python-pip python-setuptools python3 python3-pip \
-  python3-setuptools python3-yaml unzip bc libtool automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client \
-  google-cloud-sdk libncurses-dev doxygen graphviz python3.8 ninja-build bzip2 sudo
+PACKAGES=(
+    automake
+    bc
+    bzip2
+    cmake
+    docker-ce-cli
+    doxygen
+    gdb
+    git
+    google-cloud-sdk
+    graphviz
+    libncurses-dev
+    libtool
+    make
+    ninja-build
+    patch
+    python
+    python-pip
+    python-setuptools
+    python3
+    python3-pip
+    python3-setuptools
+    python3-yaml
+    python3.8
+    rsync
+    ssh-client
+    strace
+    sudo
+    tcpdump
+    time
+    tshark
+    unzip
+    wget
+    xz-utils
+    zip)
+
+# todo: remove this once kitware repo is fixed
+if [ "$ARCH" == "aarch64" ]; then
+    PACKAGES+=("cmake-data=3.10.2-1ubuntu2.18.04.1")
+else
+    PACKAGES+=("cmake-data")
+fi
+
+apt-get install -y --no-install-recommends "${PACKAGES[@]}"
 
 # Set LLVM version for each cpu architecture.
 LLVM_VERSION=10.0.0

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -81,7 +81,7 @@ PACKAGES=(
     zip)
 
 # todo: remove this once kitware repo is fixed
-if [ "$ARCH" == "aarch64" ]; then
+if [[ "$ARCH" == "aarch64" ]]; then
     PACKAGES+=("cmake-data=3.10.2-1ubuntu2.18.04.1")
 else
     PACKAGES+=("cmake-data")


### PR DESCRIPTION
Signed-off-by: Ryan Northey <ryan@synca.io>

Current build fails on arm64 with incompatibility between cmake in ubuntu repos, and cmake-data in kitware repo.

I spoke with the kitware dev, and confirmed this issue.

This pins the cmake-data version on arm64 for now, and tidies up the package list a little