### PR TITLE
Step 4: Bump bazel on windows to llvm11

### DIFF
--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -120,8 +120,8 @@ AddToPath C:\tools\ninja
 
 # LLVM to ensure a 64-bit build of the tool (VS BuildTools ships a 32-bit build)
 DownloadAndCheck $env:TEMP\LLVM-win64.exe `
-                 https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe `
-                 893f8a12506f8ad29ca464d868fb432fdadd782786a10655b86575fc7fc1a562
+                 https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe `
+                 a773ee3519ecc8d68d91f0ec72ee939cbed8ded483ba8e10899dc19bccba1e22
 RunAndCheckError $env:TEMP\LLVM-win64.exe @("/S") $true
 AddToPath $env:ProgramFiles\LLVM\bin
 

--- a/toolchains/regenerate.sh
+++ b/toolchains/regenerate.sh
@@ -38,7 +38,7 @@ esac
 
 # Bazel query is the right command so bazel won't fail itself.
 # Keep bazel versions here at most two: current master version, next version
-for BAZEL_VERSION in "3.6.0" "3.7.2"; do
+for BAZEL_VERSION in "3.7.2"; do
   for RBE_BAZEL_TARGET in ${RBE_BAZEL_TARGET_LIST}; do
     USE_BAZEL_VERSION="${BAZEL_VERSION}" bazel query ${BAZEL_QUERY_OPTIONS} ${RBE_BAZEL_TARGET}
   done


### PR DESCRIPTION
Build bazel 3.7.2, Windows llvm 11.0.0-based toolchain

- Step 1 had introduced bazel 3.7.2 in https://github.com/envoyproxy/envoy-build-tools/pull/114 for envoy
- Step 2 bumped .bazelversion to pick up bazel 3.7.2 in https://github.com/envoyproxy/envoy/pull/14134
- Step 3, we've let all builds in-flight using bazel 3.6.0 to run to completion.
- in Step 4, we add llvm 11.0.0 to the windows build tools, and reduce the target flavors of bazel to 3.7.2 alone
- afterward the toolchains are regenerated, we can proceed to step 5 of adding llvm 11.0.0 CI pipeline

Co-authored-by: Sunjay Bhatia <sunjayb@vmware.com>
