### PR TITLE
Windows build container: Rename msys2 GNU link.exe

### DIFF
--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -163,6 +163,8 @@ DownloadAndCheck $env:TEMP\msys2.tar.xz `
 RunAndCheckError "$env:TEMP\7z\7z.exe" @("x", "$env:TEMP\msys2.tar.xz", "-o$env:TEMP\msys2.tar", "-y")
 RunAndCheckError "$env:TEMP\7z\7z.exe" @("x", "$env:TEMP\msys2.tar", "-oC:\tools", "-y")
 AddToPath C:\tools\msys64\usr\bin
+# To ensure msys2 link.exe (GNU link) does not conflict with link.exe from VC Build Tools
+mv -Force C:\tools\msys64\usr\bin\link.exe C:\tools\msys64\usr\bin\gnu-link.exe
 RunAndCheckError "C:\tools\msys64\usr\bin\bash.exe" @("-c", "pacman-key --init")
 RunAndCheckError "C:\tools\msys64\usr\bin\bash.exe" @("-c", "pacman-key --populate msys2")
 # Force update of package db


### PR DESCRIPTION
So it does not conflict with MSVC link.exe. This link.exe should not be used by any Envoy build toolchain.

Before:

```
ContainerAdministrator@254d98a01089  /c
# which -a link
/usr/bin/link
/c/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/link
```

After (locally built image):

```
ContainerAdministrator@f9e50537b1b7  /c
# which -a link
/c/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Tools/MSVC/14.28.29333/bin/Hostx64/x64/link
```