### PR TITLE
Windows container build: Extend job timeout

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,7 @@ jobs:
       osFamily: "linux"
 
 - job: build_container_windows
+  timeoutInMinutes: 90
   strategy:
     matrix:
       windows2019:

--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -148,6 +148,7 @@ RunAndCheckError "cmd.exe" @("/c", "mklink", "$env:ProgramFiles\Python39\python3
 RunAndCheckError "python.exe" @("-m", "pip", "install", "--upgrade", "pip")
 # Install wheel so rules_python rules will run
 RunAndCheckError "pip.exe" @("install", "wheel")
+RunAndCheckError "pip.exe" @("install", "virtualenv")
 
 # 7z only to unpack msys2
 DownloadAndCheck $env:TEMP\7z-installer.exe `


### PR DESCRIPTION
Also add small change to add virtualenv, used by some python tasks,
might as well install it here. Mostly to ensure the container image is
rebuilt. The previous build timed out and only pushed to docker hub, not
gcr.