### PR TITLE
ubuntu: install jdk for x86_64

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -115,7 +115,7 @@ case $ARCH in
           -o /usr/local/bin/bazel
         chmod +x /usr/local/bin/bazel
         ;;
-    'aarch64' )
+    'aarch64'|'x86_64' )
         if [ "$(lsb_release -cs)" == 'xenial' ]; then
           apt install -y openjdk-8-jdk
           apt install -y ca-certificates-java


### PR DESCRIPTION
Envoy Mobile wants to use the build containers in CI but we need java and javac installed in the Ubuntu x86_64 container image to do so.

Signed-off-by: Jose Nino <jnino@lyft.com>