### PR TITLE
linux: Set locale to en_US.UTF-8

### DIFF
--- a/build_container/Dockerfile-centos
+++ b/build_container/Dockerfile-centos
@@ -20,6 +20,7 @@ COPY ./build_container_centos.sh /
 
 ENV PATH /opt/rh/rh-git218/root/usr/bin:/opt/rh/devtoolset-7/root/usr/bin:/opt/llvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 RUN ./build_container_centos.sh
+ENV LC_ALL en_US.UTF-8
 
 # In the end, remove qemu program
 RUN rm -f /usr/bin/qemu-${QEMUARCH}-static

--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -19,5 +19,7 @@ COPY ./build_container_ubuntu.sh /
 
 RUN ./build_container_ubuntu.sh
 
+ENV LANG en_US.utf8
+
 # Remove qemu program
 RUN rm -f /usr/bin/qemu-${QEMUARCH}-static

--- a/build_container/build_container_centos.sh
+++ b/build_container/build_container_centos.sh
@@ -11,6 +11,10 @@ yum install -y devtoolset-9-gcc devtoolset-9-gcc-c++ devtoolset-9-binutils java-
     rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-9-libatomic-devel openssl python27 \
     libtool autoconf tcpdump graphviz doxygen sudo
 
+# set locale
+localedef -c -f UTF-8 -i en_US en_US.UTF-8
+export LC_ALL=en_US.UTF-8
+
 ln -s /usr/bin/cmake3 /usr/bin/cmake
 
 # For LLVM to pick right libstdc++
@@ -41,7 +45,7 @@ chmod 750 /usr/sbin/tcpdump
 setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
 
 # The build_container_common.sh will be skipped when building centOS
-# image on Arm64 platform since some building issues are still unsolved. 
+# image on Arm64 platform since some building issues are still unsolved.
 # It will be fixed until those issues solved on Arm64 platform.
 if [[ $(uname -m) == "aarch64" ]] && grep -q -e rhel /etc/*-release ; then
   echo "Now, the CentOS image can not be built on arm64 platform!"

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -7,7 +7,10 @@ ARCH="$(uname -m)"
 # Setup basic requirements and install them.
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y --no-install-recommends software-properties-common apt-transport-https curl gpg-agent
+apt-get install -y --no-install-recommends locales software-properties-common apt-transport-https curl gpg-agent
+
+# set locale
+localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 # gcc-9
 add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/build_container/docker_build_linux.sh
+++ b/build_container/docker_build_linux.sh
@@ -43,3 +43,6 @@ do
     echo "Build the $arch image"
     build_image $arch
 done
+
+echo "Test linux container: ${IMAGE_NAME}:${CONTAINER_NAME}"
+docker run --rm -v "$(pwd)/docker_test_linux.sh":/test.sh "${IMAGE_NAME}:${CONTAINER_TAG}-amd64" /test.sh

--- a/build_container/docker_test_linux.sh
+++ b/build_container/docker_test_linux.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# ensure python can print unicode
+python3 -c "print(chr(9786))"


### PR DESCRIPTION
Sets locale to utf-8 in ubuntu and centos build images

Make python unicode happy

Also adds a test to ensure that python can handle utf-8 as is required in envoy build environment