### PR TITLE
python: Make python3.8 default python interpreter

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -148,6 +148,9 @@ chgrp pcap /usr/sbin/tcpdump
 chmod 750 /usr/sbin/tcpdump
 setcap cap_net_raw,cap_net_admin=eip /usr/sbin/tcpdump
 
+# make python3.8 the default python3 interpreter
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+
 # virtualenv
 pip3 install -U virtualenv
 


### PR DESCRIPTION
currently the build image installs both python3.6 and python3.8

some of the ci requires > 3.7 and currently hardcodes to use python3.8 (cve_scan)

this change makes 3.8 the default - which appears to work for all tests (so far...) - and removes the need to specify the version

we may wish to remove the python3.6 install altogether