### PR TITLE
python: Remove pyyaml from env

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -70,7 +70,6 @@ PACKAGES=(
     python3
     python3-pip
     python3-setuptools
-    python3-yaml
     python3.8
     rsync
     ssh-client


### PR DESCRIPTION
any python environments should install their own pip dependencies rather than having them in the build container

currently, this causes ci to pass tests, where it would fail locally, not using the build image