### PR TITLE
revert: #138 readd pyyaml

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -73,6 +73,7 @@ PACKAGES=(
     python3
     python3-pip
     python3-setuptools
+    python3-yaml
     python3.8
     python3.8-dev
     rpm


### PR DESCRIPTION
it turns out that this is required by a the clang-tidy-diff script, and its not so easy to add this dep any other way atm