### PR TITLE
Update Windows components to 2022-Jan-31

### DIFF
--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -12,6 +12,10 @@ RUN chmod +x /usr/bin/qemu-*
 
 FROM ${IMAGEARCH}ubuntu:bionic
 ARG QEMUARCH
+
+# Workaround for: https://issuetracker.google.com/issues/216325949
+ENV CLOUDSDK_PYTHON=python3
+
 COPY --from=qemu /usr/bin/qemu-${QEMUARCH}-static /usr/bin/
 
 COPY ./build_container_common.sh /

--- a/build_container/build_container_windows.ps1
+++ b/build_container/build_container_windows.ps1
@@ -75,15 +75,15 @@ mkdir -Force C:\tools
 # Bazelisk
 mkdir -Force C:\tools\bazel
 DownloadAndCheck C:\tools\bazel\bazel.exe `
-                 https://github.com/bazelbuild/bazelisk/releases/download/v1.10.1/bazelisk-windows-amd64.exe `
-                 9a89e6a8cc0a3aea37affcf8c146d8925ffbda1d2290c0c6a845ea81e05de62c
+                 https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-windows-amd64.exe `
+                 0eca0630e072434c63614b009bf5b63a7dff489a8676b560ce63e0d91ab731cd
 AddToPath C:\tools\bazel
 
 # VS 2019 Build Tools
-# Pinned to version 16.9.4 downloaded on 4/14/2021 via https://aka.ms/vs/16/release/vs_buildtools.exe
-DownloadAndCheck $env:TEMP\vs_buildtools.exe `
-                 https://download.visualstudio.microsoft.com/download/pr/3105fcfe-e771-41d6-9a1c-fc971e7d03a7/67584dbce4956291c76a5deabbadc15c9ad6a50d6a5f4458765b6bd3a924aead/vs_BuildTools.exe `
-                 67584dbce4956291c76a5deabbadc15c9ad6a50d6a5f4458765b6bd3a924aead
+# Pinned to version 16.9.4 downloaded on 1/31/2022 via https://aka.ms/vs/16/release/vs_BuildTools.exe
+DownloadAndCheck $env:TEMP\vs_BuildTools.exe `
+                 https://download.visualstudio.microsoft.com/download/pr/9a26f37e-6001-429b-a5db-c5455b93953c/460d80ab276046de2455a4115cc4e2f1e6529c9e6cb99501844ecafd16c619c4/vs_BuildTools.exe `
+                 460d80ab276046de2455a4115cc4e2f1e6529c9e6cb99501844ecafd16c619c4
 # See: https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2019#c-build-tools
 # Other dependent/required components including the "Microsoft.VisualStudio.Workload.MSBuildTools"
 # are added by the installer, do not need to be listed below, and cannot be supressed.
@@ -92,29 +92,29 @@ echo @"
   "version": "1.0",
   "components": [
     "Microsoft.VisualStudio.Workload.VCTools",
-    "Microsoft.VisualStudio.Component.Windows10SDK.19041",
+    "Microsoft.VisualStudio.Component.Windows11SDK.22000",
     "Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
   ]
 }
 "@ > $env:TEMP\vs_buildtools_config
-RunAndCheckError "cmd.exe" @("/s", "/c", "$env:TEMP\vs_buildtools.exe --addProductLang en-US --quiet --wait --norestart --nocache --config $env:TEMP\vs_buildtools_config")
+RunAndCheckError "cmd.exe" @("/s", "/c", "$env:TEMP\vs_BuildTools.exe --addProductLang en-US --quiet --wait --norestart --nocache --config $env:TEMP\vs_buildtools_config")
 $msvcBasePath = "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC"
 $msvcFullPath = Join-Path -Path $msvcBasePath -ChildPath "Tools\MSVC\*\bin\Hostx64\x64" -Resolve
 AddToPath $msvcFullPath
 [System.Environment]::SetEnvironmentVariable('BAZEL_VC', $msvcBasePath)
 
 # MS SDK - Debug Tools
-# Pinned to SDK version 2004 release 12/16/2020 link from https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/
+# Pinned to SDK version 2004 release 12/16/2020 link from https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/
 DownloadAndCheck $env:TEMP\winsdksetup.exe `
-                 https://download.microsoft.com/download/4/d/2/4d2b7011-606a-467e-99b4-99550bf24ffc/windowssdk/winsdksetup.exe `
-		 42d2774274d1135fc598c180c2acbf2321eb4192f59e511e6ac7772870bf6de1
+                 https://download.microsoft.com/download/d/8/f/d8ff148b-450c-40b3-aeed-2a3944e66bbd/windowssdk/winsdksetup.exe `
+		 4d73ddc82caa1cbe82dffdc24b7cef368919e077bad984357d447568feab1f5f
 RunAndCheckError "cmd.exe" @("/s", "/c", "$env:TEMP\winsdksetup.exe /features OptionId.WindowsDesktopDebuggers /quiet /norestart")
 AddToPath "C:\Program Files (x86)\Windows Kits\10\Debuggers\x64"
 
 # CMake to ensure a 64-bit build of the tool (VS BuildTools ships a 32-bit build)
 DownloadAndCheck $env:TEMP\cmake.msi `
-                 https://github.com/Kitware/CMake/releases/download/v3.20.1/cmake-3.20.1-windows-x86_64.msi `
-                 a2eb2811aada9f4830281aa407231b9295dcac4b18bdbefc35d9dd71775110e8
+                 https://github.com/Kitware/CMake/releases/download/v3.22.2/cmake-3.22.2-windows-x86_64.msi `
+                 aab9fb9d6a7a18458df2f3900c9d31218a2d38076f3c3f2c6004b800a9be0a3d
 RunAndCheckError "msiexec.exe" @("/i", "$env:TEMP\cmake.msi", "/quiet", "/norestart") $true
 AddToPath $env:ProgramFiles\CMake\bin
 
@@ -143,8 +143,8 @@ AddToPath C:\tools\nasm-$nasmVersion
 
 # Python3 (do not install via msys2 or the MS store's flavors, this version follows Win32 semantics)
 DownloadAndCheck $env:TEMP\python3-installer.exe `
-                 https://www.python.org/ftp/python/3.9.4/python-3.9.4-amd64.exe `
-                 58e6bb9d08fd250c1defb7a7a7247993b4ea349518ba877abb6364de85029e04
+                 https://www.python.org/ftp/python/3.9.9/python-3.9.9-amd64.exe `
+                 137d59e5c0b01a8f1bdcba08344402ae658c81c6bf03b6602bd8b4e951ad0714
 # python installer needs to be run as an installer with Start-Process
 RunAndCheckError "$env:TEMP\python3-installer.exe" @("/quiet", "InstallAllUsers=1", "Include_launcher=0", "InstallLauncherAllUsers=0") $true
 AddToPath $env:ProgramFiles\Python39
@@ -167,8 +167,8 @@ RunAndCheckError "$env:TEMP\7z-installer.exe" @("/S", "/D=$quo$env:TEMP\7z$quo")
 
 # msys2 with additional required packages
 DownloadAndCheck $env:TEMP\msys2.tar.xz `
-                 https://github.com/msys2/msys2-installer/releases/download/2021-02-28/msys2-base-x86_64-20210228.tar.xz `
-                 3f2ceb097a081789d9d497e0d3df8d99c16a1591b9984b0469440cd5bfa65092
+                 https://github.com/msys2/msys2-installer/releases/download/2022-01-28/msys2-base-x86_64-20220128.tar.xz `
+                 b667a7ec3840c0437c718d6851c93794bd8a6837ba642fd90702e8769febad6a
 RunAndCheckError "$env:TEMP\7z\7z.exe" @("x", "$env:TEMP\msys2.tar.xz", "-o$env:TEMP\msys2.tar", "-y")
 RunAndCheckError "$env:TEMP\7z\7z.exe" @("x", "$env:TEMP\msys2.tar", "-oC:\tools", "-y")
 AddToPath C:\tools\msys64\usr\bin


### PR DESCRIPTION
Bumps bazelisk, visual studio buildtools, windows sdk, cmake, python and msys2
to their current revisions. No other patckages updated as of this date.

Visual Studio is bumped to the latest of VS2019 (version 19).  Holding off for
a later toolchain rebuild to bring this up to Visual Studio 2022 (version 20)
including better C++20 support. We will need to examine how the Universal CRT
is affected by that bump.

Also pick up Ubuntu python envvar workaround by @phlax 

Cherry-picks: https://github.com/envoyproxy/envoy-build-tools/pull/159
Resolves issue: https://github.com/envoyproxy/envoy-build-tools/issues/160
Signed-off-by: William A Rowe Jr <wrowe@vmware.com>