### PR TITLE
Fix build_container_common.sh for non-x86_64 builds

### DIFF
--- a/build_container/build_container_common.sh
+++ b/build_container/build_container_common.sh
@@ -77,7 +77,7 @@ rm -rf "lcov-${LCOV_VERSION}" "./lcov-${LCOV_VERSION}.tar.gz"
 
 # Install sanitizer instrumented libc++, skipping for architectures other than x86_64 for now.
 if [[ "$(uname -m)" != "x86_64" ]]; then
-  exit 0
+  return 0
 fi
 
 export PATH="/opt/llvm/bin:${PATH}"


### PR DESCRIPTION
Th Ubuntu build script sources this file, but it would exit instead of return causing some later parts of the build script not to run on non-x86_64 builds.