### PR TITLE
Install Java 8, Android command line tools and SDK for Ubuntu

### DIFF
--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -9,3 +9,6 @@ COPY ./build_container_ubuntu.sh /
 RUN ./build_container_ubuntu.sh
 
 ENV LANG en_US.utf8
+ENV ANDROID_HOME /.android/sdk
+ENV ANDROID_SDK_ROOT /.android/sdk
+ENV ANDROID_NDK_HOME /.android/sdk/ndk/21.4.7075529

--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -6,9 +6,12 @@ ENV CLOUDSDK_PYTHON=python3
 COPY ./build_container_common.sh /
 COPY ./build_container_ubuntu.sh /
 
+ENV ANDROID_SDK_INSTALL_TARGET /.android
+ENV ANDROID_HOME /.android/sdk
+ENV ANDROID_SDK_ROOT /.android/sdk
+ENV ANDROID_NDK_VERSION 21.4.7075529
+ENV ANDROID_NDK_HOME /.android/sdk/ndk/21.4.7075529
+
 RUN ./build_container_ubuntu.sh
 
 ENV LANG en_US.utf8
-ENV ANDROID_HOME /.android/sdk
-ENV ANDROID_SDK_ROOT /.android/sdk
-ENV ANDROID_NDK_HOME /.android/sdk/ndk/21.4.7075529

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -132,6 +132,29 @@ update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 # TODO(phlax): use hashed requirements
 pip3 install -U pyyaml virtualenv
 
+########################
+# Begin JDK installation
+########################
+
+# Add Azul's public key
+apt-key adv \
+  --keyserver hkp://keyserver.ubuntu.com:80 \
+  --recv-keys 0xB1998361219BD9C9
+
+# Download and install the package that adds 
+# the Azul APT repository to the list of sources 
+curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
+
+# Install the Java 8 JDK
+apt-get install -y ./zulu-repo_1.0.0-3_all.deb
+apt-get update -y
+apt-get install -y zulu8-jdk
+rm ./zulu-repo_1.0.0-3_all.deb
+
+######################
+# End JDK installation
+######################
+
 ##################################
 # Begin Android tools installation
 ##################################

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -156,8 +156,9 @@ function install_android_tools() {
     # Install Android tools
     #######################
 
-    sdk_install_target="/github/home/.android"
-    mkdir -p "$sdk_install_target/sdk"
+    sdk_install_target="/.android"
+    android_home="$sdk_install_target/sdk"
+    mkdir -p "$android_home"
     pushd "$sdk_install_target"
 
     cmdline_file="commandlinetools-linux-7583922_latest.zip"
@@ -166,16 +167,10 @@ function install_android_tools() {
     mkdir -p sdk/cmdline-tools/latest
     mv cmdline-tools/* sdk/cmdline-tools/latest
 
-    ANDROID_HOME="$(realpath "$sdk_install_target/sdk")"
-    SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
-
-    echo "y" | $SDKMANAGER --install "ndk;21.4.7075529"
-    $SDKMANAGER --install "platforms;android-30"
-    $SDKMANAGER --install "build-tools;30.0.2"
-
-    export "ANDROID_HOME=${ANDROID_HOME}"
-    export "ANDROID_SDK_ROOT=${ANDROID_HOME}"
-    export "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/21.4.7075529"
+    sdkmanager=$android_home/cmdline-tools/latest/bin/sdkmanager
+    echo "y" | $sdkmanager --install "ndk;21.4.7075529"
+    $sdkmanager --install "platforms;android-30"
+    $sdkmanager --install "build-tools;30.0.2"
 
     popd
 }

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -132,6 +132,36 @@ update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 # TODO(phlax): use hashed requirements
 pip3 install -U pyyaml virtualenv
 
+##################################
+# Begin Android tools installation
+##################################
+
+sdk_install_target="/github/home/.android"
+mkdir -p "$sdk_install_target/sdk"
+pushd "$sdk_install_target"
+cmdline_file="commandlinetools-linux-7583922_latest.zip"
+curl -OL "https://dl.google.com/android/repository/$cmdline_file"
+unzip "$cmdline_file"
+mkdir -p sdk/cmdline-tools/latest
+mv cmdline-tools/* sdk/cmdline-tools/latest
+
+ANDROID_HOME="$(realpath "$sdk_install_target/sdk")"
+SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+
+echo "y" | $SDKMANAGER --install "ndk;21.4.7075529"
+$SDKMANAGER --install "platforms;android-30"
+$SDKMANAGER --install "build-tools;30.0.2"
+
+export "ANDROID_HOME=${ANDROID_HOME}"
+export "ANDROID_SDK_ROOT=${ANDROID_HOME}"
+export "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/21.4.7075529"
+
+popd
+
+################################
+# End Android tools installation
+################################
+
 source ./build_container_common.sh
 
 # Soft link the gcc compiler (required by python env)

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -132,58 +132,59 @@ update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 # TODO(phlax): use hashed requirements
 pip3 install -U pyyaml virtualenv
 
-########################
-# Begin JDK installation
-########################
+function install_android_tools() {
+    #############
+    # Install JDK
+    #############
 
-# Add Azul's public key
-apt-key adv \
-  --keyserver hkp://keyserver.ubuntu.com:80 \
-  --recv-keys 0xB1998361219BD9C9
+    # Add Azul's public key
+    apt-key adv \
+        --keyserver hkp://keyserver.ubuntu.com:80 \
+        --recv-keys 0xB1998361219BD9C9
 
-# Download and install the package that adds 
-# the Azul APT repository to the list of sources 
-curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
+    # Download and install the package that adds 
+    # the Azul APT repository to the list of sources 
+    curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
 
-# Install the Java 8 JDK
-apt-get install -y ./zulu-repo_1.0.0-3_all.deb
-apt-get update -y
-apt-get install -y zulu8-jdk
-rm ./zulu-repo_1.0.0-3_all.deb
+    # Install the Java 8 JDK
+    apt-get install -y ./zulu-repo_1.0.0-3_all.deb
+    apt-get update -y
+    apt-get install -y zulu8-jdk
+    rm ./zulu-repo_1.0.0-3_all.deb
 
-######################
-# End JDK installation
-######################
+    #######################
+    # Install Android tools
+    #######################
 
-##################################
-# Begin Android tools installation
-##################################
+    sdk_install_target="/github/home/.android"
+    mkdir -p "$sdk_install_target/sdk"
+    pushd "$sdk_install_target"
 
-sdk_install_target="/github/home/.android"
-mkdir -p "$sdk_install_target/sdk"
-pushd "$sdk_install_target"
-cmdline_file="commandlinetools-linux-7583922_latest.zip"
-curl -OL "https://dl.google.com/android/repository/$cmdline_file"
-unzip "$cmdline_file"
-mkdir -p sdk/cmdline-tools/latest
-mv cmdline-tools/* sdk/cmdline-tools/latest
+    cmdline_file="commandlinetools-linux-7583922_latest.zip"
+    curl -OL "https://dl.google.com/android/repository/$cmdline_file"
+    unzip "$cmdline_file"
+    mkdir -p sdk/cmdline-tools/latest
+    mv cmdline-tools/* sdk/cmdline-tools/latest
 
-ANDROID_HOME="$(realpath "$sdk_install_target/sdk")"
-SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+    ANDROID_HOME="$(realpath "$sdk_install_target/sdk")"
+    SDKMANAGER=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
 
-echo "y" | $SDKMANAGER --install "ndk;21.4.7075529"
-$SDKMANAGER --install "platforms;android-30"
-$SDKMANAGER --install "build-tools;30.0.2"
+    echo "y" | $SDKMANAGER --install "ndk;21.4.7075529"
+    $SDKMANAGER --install "platforms;android-30"
+    $SDKMANAGER --install "build-tools;30.0.2"
 
-export "ANDROID_HOME=${ANDROID_HOME}"
-export "ANDROID_SDK_ROOT=${ANDROID_HOME}"
-export "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/21.4.7075529"
+    export "ANDROID_HOME=${ANDROID_HOME}"
+    export "ANDROID_SDK_ROOT=${ANDROID_HOME}"
+    export "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/21.4.7075529"
 
-popd
+    popd
+}
 
-################################
-# End Android tools installation
-################################
+case $ARCH in
+    'x86_64' )
+        install_android_tools
+        ;;
+esac
 
 source ./build_container_common.sh
 

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -156,10 +156,8 @@ function install_android_tools() {
     # Install Android tools
     #######################
 
-    sdk_install_target="/.android"
-    android_home="$sdk_install_target/sdk"
-    mkdir -p "$android_home"
-    pushd "$sdk_install_target"
+    mkdir -p "$ANDROID_HOME"
+    pushd "$ANDROID_SDK_INSTALL_TARGET"
 
     cmdline_file="commandlinetools-linux-7583922_latest.zip"
     curl -OL "https://dl.google.com/android/repository/$cmdline_file"
@@ -167,8 +165,8 @@ function install_android_tools() {
     mkdir -p sdk/cmdline-tools/latest
     mv cmdline-tools/* sdk/cmdline-tools/latest
 
-    sdkmanager=$android_home/cmdline-tools/latest/bin/sdkmanager
-    echo "y" | $sdkmanager --install "ndk;21.4.7075529"
+    sdkmanager=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
+    echo "y" | $sdkmanager --install "ndk;$ANDROID_NDK_VERSION"
     $sdkmanager --install "platforms;android-30"
     $sdkmanager --install "build-tools;30.0.2"
 


### PR DESCRIPTION
These are used for Envoy Mobile's CI and currently installed on every CI job run: https://github.com/envoyproxy/envoy/blob/main/mobile/ci/linux_ci_setup.sh