### PR TITLE
Revert "Install Java 8, Android command line tools and SDK for Ubuntu"

### DIFF
--- a/build_container/Dockerfile-ubuntu
+++ b/build_container/Dockerfile-ubuntu
@@ -6,12 +6,6 @@ ENV CLOUDSDK_PYTHON=python3
 COPY ./build_container_common.sh /
 COPY ./build_container_ubuntu.sh /
 
-ENV ANDROID_SDK_INSTALL_TARGET /.android
-ENV ANDROID_HOME /.android/sdk
-ENV ANDROID_SDK_ROOT /.android/sdk
-ENV ANDROID_NDK_VERSION 21.4.7075529
-ENV ANDROID_NDK_HOME /.android/sdk/ndk/21.4.7075529
-
 RUN ./build_container_ubuntu.sh
 
 ENV LANG en_US.utf8

--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -132,53 +132,6 @@ update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1
 # TODO(phlax): use hashed requirements
 pip3 install -U pyyaml virtualenv
 
-function install_android_tools() {
-    #############
-    # Install JDK
-    #############
-
-    # Add Azul's public key
-    apt-key adv \
-        --keyserver hkp://keyserver.ubuntu.com:80 \
-        --recv-keys 0xB1998361219BD9C9
-
-    # Download and install the package that adds 
-    # the Azul APT repository to the list of sources 
-    curl -O https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
-
-    # Install the Java 8 JDK
-    apt-get install -y ./zulu-repo_1.0.0-3_all.deb
-    apt-get update -y
-    apt-get install -y zulu8-jdk
-    rm ./zulu-repo_1.0.0-3_all.deb
-
-    #######################
-    # Install Android tools
-    #######################
-
-    mkdir -p "$ANDROID_HOME"
-    pushd "$ANDROID_SDK_INSTALL_TARGET"
-
-    cmdline_file="commandlinetools-linux-7583922_latest.zip"
-    curl -OL "https://dl.google.com/android/repository/$cmdline_file"
-    unzip "$cmdline_file"
-    mkdir -p sdk/cmdline-tools/latest
-    mv cmdline-tools/* sdk/cmdline-tools/latest
-
-    sdkmanager=$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager
-    echo "y" | $sdkmanager --install "ndk;$ANDROID_NDK_VERSION"
-    $sdkmanager --install "platforms;android-30"
-    $sdkmanager --install "build-tools;30.0.2"
-
-    popd
-}
-
-case $ARCH in
-    'x86_64' )
-        install_android_tools
-        ;;
-esac
-
 source ./build_container_common.sh
 
 # Soft link the gcc compiler (required by python env)


### PR DESCRIPTION
Reverts envoyproxy/envoy-build-tools#188

This grew the Docker image by an unreasonable amount, going from 1.79 GB to 3.77 GB.