### PR TITLE
install golang package for Ubuntu.

### DIFF
--- a/build_container/build_container_ubuntu.sh
+++ b/build_container/build_container_ubuntu.sh
@@ -56,6 +56,7 @@ PACKAGES=(
     gdb
     git
     gnupg2
+    golang
     google-cloud-sdk
     graphviz
     jq


### PR DESCRIPTION
Since we need to check the Go code format by the gofmt command in Envoy CI, which is included in the golang package.
see: https://github.com/envoyproxy/envoy/pull/24819