### PR TITLE
revert: LLVM + NDK updates

### DIFF
--- a/docker/linux/ubuntu/Dockerfile
+++ b/docker/linux/ubuntu/Dockerfile
@@ -8,7 +8,7 @@ ARG ANDROID_CLI_TOOLS=https://dl.google.com/android/repository/commandlinetools-
     BAZELISK_SHA256SUM=ce52caa51ef9e509fb6b7e5ad892e5cf10feb0794b0aed4d2f36adb00a1a2779 \
     BAZELISK_SHA256SUM_ARM64=6070bf70915e92b3a5ce8eee6f4a8a0968bb350be2a98b80b0fd2fc13ce8a254 \
     BAZELISK_VERSION=1.18.0 \
-    CLANG_TOOLS_SHA256SUM=430fadf6b4b287686e7043792e4defc4b54a4911d02bda540aa5acf63a0de5fa \
+    CLANG_TOOLS_SHA256SUM=f49de4b4502a6608425338e2d93bbe4529cac0a22f2dc1c119ef175a4e1b5bf0 \
     DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.utf8 \
     LCOV_VERSION=1.15 \
@@ -18,10 +18,10 @@ ARG ANDROID_CLI_TOOLS=https://dl.google.com/android/repository/commandlinetools-
     LLVM_DISTRO_ARM64=aarch64-linux-gnu \
     LLVM_DISTRO_PPC64LE=powerpc64le-linux-ubuntu-18.04 \
     LLVM_DOWNLOAD_PREFIX=https://github.com/llvm/llvm-project/releases/download/llvmorg- \
-    LLVM_SHA256SUM=2b8a69798e8dddeb57a186ecac217a35ea45607cb2b3cf30014431cff4340ad1 \
-    LLVM_SHA256SUM_ARM64=b750ba3120e6153fc5b316092f19b52cf3eb64e19e5f44bd1b962cb54a20cf0a \
-    LLVM_SHA256SUM_PPC64LE=7fc9f07ff0fcf191df93fe4adc1da555e43f62fe1d3ddafb15c943f72b1bda17 \
-    LLVM_VERSION=16.0.0 \
+    LLVM_SHA256SUM=61582215dafafb7b576ea30cc136be92c877ba1f1c31ddbbd372d6d65622fef5 \
+    LLVM_SHA256SUM_ARM64=1792badcd44066c79148ffeb1746058422cc9d838462be07e3cb19a4b724a1ee \
+    LLVM_SHA256SUM_PPC64LE=2d504c4920885c86b306358846178bc2232dfac83b47c3b1d05861a8162980e6 \
+    LLVM_VERSION=14.0.0 \
     ZULU_INSTALL_DEB=https://cdn.azul.com/zulu/bin/zulu-repo_1.0.0-3_all.deb
 ENV LANG=$LANG
 SHELL ["/bin/bash", "-ec"]
@@ -78,8 +78,8 @@ COPY \
 # mobile
 FROM full as mobile
 ENV ANDROID_HOME=/.android/sdk \
-    ANDROID_NDK_HOME=/.android/sdk/ndk/27.0.11718014 \
-    ANDROID_NDK_VERSION=27.0.11718014-beta1 \
+    ANDROID_NDK_HOME=/.android/sdk/ndk/21.4.7075529 \
+    ANDROID_NDK_VERSION=21.4.7075529 \
     ANDROID_SDK_INSTALL_TARGET=/.android \
     ANDROID_SDK_ROOT=/.android/sdk
 RUN --mount=type=tmpfs,target=/var/cache/apt \

--- a/docker/windows/docker_windows.ps1
+++ b/docker/windows/docker_windows.ps1
@@ -131,8 +131,8 @@ AddToPath C:\tools\ninja
 
 # LLVM to ensure a 64-bit build of the tool (VS BuildTools ships a 32-bit build)
 DownloadAndCheck $env:TEMP\LLVM-win64.exe `
-                 https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.0/LLVM-16.0.0-win64.exe `
-                 e41295133d6d24cc8133702768ddb4e3bffd9f9b4a9b2faf9cd0a045cfc90abc
+                 https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/LLVM-14.0.0-win64.exe `
+                 15d52a38436417843a56883730a7e358a8afa0510a003596ee23963339a913f7
 RunAndCheckError $env:TEMP\LLVM-win64.exe @("/S") $true
 AddToPath $env:ProgramFiles\LLVM\bin
 


### PR DESCRIPTION
Revert "mobile/build: Bump NDK -> r27beta (#343)"
This reverts commit 6474ce1eddb779bd0fd1ca3a60995687fbf00bb4.
Revert "build/image: Update llvm -> 16.0.0 (#342)"
This reverts commit f29d90fdcd2e8e1b92f1eb7aa75d45fbb79d0d84.