### PR TITLE
Add a variant image for openssl

### DIFF
--- a/docker/linux/build.sh
+++ b/docker/linux/build.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-UBUNTU_DOCKER_VARIANTS=("ci" "mobile" "test")
+UBUNTU_DOCKER_VARIANTS=("ci" "mobile" "test" "openssl")
 IMAGE_TAGS=${IMAGE_TAGS:-}
 
 
@@ -64,6 +64,7 @@ if [[ -z "${NO_BUILD_VARIANTS}" ]]; then
     # variants are only pushed for the dockerhub image (not other `IMAGE_TAGS`)
     build_and_push_variants
 fi
+
 
 if [[ -n "${IMAGE_TAGS}" ]]; then
     for IMAGE_TAG in "${IMAGE_TAGS[@]}"; do

--- a/docker/linux/ubuntu/Dockerfile
+++ b/docker/linux/ubuntu/Dockerfile
@@ -88,4 +88,13 @@ RUN --mount=type=tmpfs,target=/var/cache/apt \
     && mobile_install
 
 
+# OpenSSL
+FROM full AS openssl
+RUN --mount=type=bind,source=/common_fun.sh,target=/common_fun.sh \
+    --mount=type=bind,source=/ubuntu/fun.sh,target=/ubuntu/fun.sh \
+    . ./ubuntu/fun.sh \
+    && install_openssl 3.0.16 57e03c50feab5d31b152af2b764f10379aecd8ee92f16c985983ce4a99f7ef86 \
+    && install_openssl 3.2.4 b23ad7fd9f73e43ad1767e636040e88ba7c9e5775bfa5618436a0dd2c17c3716
+
+
 FROM full

--- a/docker/linux/ubuntu/fun.sh
+++ b/docker/linux/ubuntu/fun.sh
@@ -200,3 +200,24 @@ install_llvm () {
     install_san
     install_gn
 }
+
+install_openssl () {
+    local version=$1
+    local sha256sum=$2
+    local major_minor_version="${version%.*}"
+    local openssl_dir="/opt/openssl${major_minor_version}"
+    local source_dir="${openssl_dir}/src"
+
+    download_and_check openssl.tar.gz "https://github.com/openssl/openssl/releases/download/openssl-${version}/openssl-${version}.tar.gz" "${sha256sum}"
+    mkdir -p "${source_dir}"
+    tar zxf openssl.tar.gz --strip-components=1 -C "${source_dir}"
+    rm openssl.tar.gz
+
+    pushd "${source_dir}"
+    ./config -d --prefix="${openssl_dir}" --openssldir="${openssl_dir}"
+    make -j && make install_sw
+    popd
+    rm -rf "${source_dir}"
+
+    chown -R root:root "${openssl_dir}"
+}

--- a/docker/push.sh
+++ b/docker/push.sh
@@ -5,6 +5,8 @@
 set -e
 
 IMAGE_PREFIX="${IMAGE_PREFIX:-envoyproxy/envoy-build-}"
+OS_FAMILY="${OS_FAMILY:-linux}"
+OS_DISTRO="${OS_DISTRO:-ubuntu}"
 GCR_IMAGE_PREFIX=gcr.io/envoy-ci/
 # Enable docker experimental
 export DOCKER_CLI_EXPERIMENTAL=enabled


### PR DESCRIPTION
It allows installation of multiple versions at the same time, under `/opt/opensslX.Y` directories. Users (and jobs) can adjust their build environment (e.g. by setting `LD_LIBRARY_PATH`) to the desired version.