### PR TITLE
Revert "docker/debian: Install git in the base image (#471)"

### DIFF
--- a/docker/linux/debian/fun.sh
+++ b/docker/linux/debian/fun.sh
@@ -13,7 +13,6 @@ COMMON_PACKAGES=(
     apt-transport-https
     ca-certificates
     curl
-    git
     libtinfo5
     patch)
 CI_PACKAGES=(git gosu sudo)
@@ -28,6 +27,7 @@ DEBIAN_PACKAGES=(
     doxygen
     expect
     gdb
+    git
     graphviz
     jq
     libcap2-bin


### PR DESCRIPTION
This reverts commit b6d1b39a63bb1cdc1466002a9c5678a08eb61eff.