### PR TITLE
ci(lint): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,9 @@ on:
     paths:
     - '**/*.sh'
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `lint` workflow only runs lint checks. No GitHub API writes, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.